### PR TITLE
Enables get_namespace to return namespace when input adopts Array API spec

### DIFF
--- a/array_api_compat/common/_helpers.py
+++ b/array_api_compat/common/_helpers.py
@@ -60,7 +60,7 @@ def get_namespace(*xs, _use_compat=True):
         if isinstance(x, (tuple, list)):
             namespaces.add(get_namespace(*x, _use_compat=_use_compat))
         elif hasattr(x, '__array_namespace__'):
-            namespaces.add(x.__array_namespace__)
+            namespaces.add(x.__array_namespace__())
         elif _is_numpy_array(x):
             if _use_compat:
                 from .. import numpy as numpy_namespace

--- a/tests/test_get_namespace.py
+++ b/tests/test_get_namespace.py
@@ -12,3 +12,10 @@ def test_get_namespace(library):
     expected_namespace = getattr(array_api_compat, library)
     assert namespace is expected_namespace
 
+
+@pytest.mark.parametrize("array_namespace", ["cupy.array_api", "numpy.array_api"])
+def test_get_namespace_returns_actual_namespace(array_namespace):
+    xp = pytest.importorskip(array_namespace)
+    X = xp.asarray([1, 2, 3])
+    xp_ = array_api_compat.get_namespace(X)
+    assert xp_ is xp


### PR DESCRIPTION
This PR enables `get_namespace` to return the Array API namespace if the input already adapts the Array API standard.