### PR TITLE
MNT: Add requires-python metadata

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,6 +15,7 @@ setup(
     long_description_content_type="text/markdown",
     url="https://data-apis.org/array-api-compat/",
     license="MIT",
+    python_requires=">=3.8",
     extras_require={
         "numpy": "numpy",
         "cupy": "cupy",

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,10 @@ setup(
     },
     classifiers=[
         "Programming Language :: Python :: 3",
+        "Programming Language :: Python :: 3.8",
+        "Programming Language :: Python :: 3.9",
+        "Programming Language :: Python :: 3.10",
+        "Programming Language :: Python :: 3.11",
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],


### PR DESCRIPTION
* Add requires-python metadata through the addition of setuptools's python_requires in setup.py.
   - c.f. https://peps.python.org/pep-0621/#requires-python
   - Set minimum required python to 3.8 as Python 3.7 is EOL as of 2023-06-27.
     c.f. https://devguide.python.org/versions/#unsupported-versions

* The addition of requires-python is to provide guards to keep older CPython versions from installing releases that could contain unrunnable code.

c.f. https://github.com/tensorflow/probability/pull/1724

Python 3.8 is also the lower bound on versions tested in CI.

https://github.com/data-apis/array-api-compat/blob/ae7aa8efe660e75bd4f7605dd4f5fddcc4bf34d9/.github/workflows/tests.yml#L6-L8