### PR TITLE
CI: Add publishing to PyPI and TestPyPI with trusted publishers

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,12 @@
+version: 2
+updates:
+  # Maintain dependencies for GitHub Actions
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    labels:
+      - "github-actions"
+      - "dependencies"
+    reviewers:
+      - "asmeurer"

--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -1,0 +1,105 @@
+name: publish distributions
+on:
+  push:
+    branches:
+    - main
+    tags:
+    - [0-9]+.[0-9]+
+    - [0-9]+.[0-9]+.[0-9]+
+  pull_request:
+    branches:
+    - main
+  release:
+    types: [published]
+  workflow_dispatch:
+    inputs:
+      publish:
+        type: choice
+        description: 'Publish to TestPyPI?'
+        options:
+        - false
+        - true
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build Python distribution
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v3
+      with:
+        fetch-depth: 0
+
+    - name: Set up Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: '3.x'
+
+    - name: Install python-build and twine
+      run: |
+        python -m pip install --upgrade pip setuptools
+        python -m pip install build twine
+        python -m pip list
+
+    - name: Build a wheel and a sdist
+      run: |
+        PYTHONWARNINGS=error,default::DeprecationWarning python -m build .
+
+    - name: Verify the distribution
+      run: twine check --strict dist/*
+
+    - name: List contents of sdist
+      run: python -m tarfile --list dist/array_api_compat-*.tar.gz
+
+    - name: List contents of wheel
+      run: python -m zipfile --list dist/array_api_compat-*.whl
+
+    - name: Upload distribution artifact
+      uses: actions/upload-artifact@v3
+      with:
+        name: dist-artifact
+        path: dist
+
+  publish:
+    name: Publish Python distribution to (Test)PyPI
+    if: github.event_name != 'pull_request' && github.repository == 'data-apis/array-api-compat'
+    needs: build
+    runs-on: ubuntu-latest
+    # Mandatory for publishing with a trusted publisher
+    # c.f. https://docs.pypi.org/trusted-publishers/using-a-publisher/
+    permissions:
+      id-token: write
+    # Restrict to the environment set for the trusted publisher
+    environment:
+      name: publish-package
+
+    steps:
+    - name: Download distribution artifact
+      uses: actions/download-artifact@v3
+      with:
+        name: dist-artifact
+        path: dist
+
+    - name: List all files
+      run: ls -lh dist
+
+    - name: Publish distribution 📦 to Test PyPI
+      # Publish to TestPyPI on tag events of if manually triggered
+      # Compare to 'true' string as booleans get turned into strings in the console
+      if: >-
+        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+        || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true')
+      uses: pypa/gh-action-pypi-publish@v1.8.10
+      with:
+        repository-url: https://test.pypi.org/legacy/
+        print-hash: true
+
+    - name: Publish distribution 📦 to PyPI
+      if: github.event_name == 'release' && github.event.action == 'published'
+      uses: pypa/gh-action-pypi-publish@v1.8.10
+      with:
+        print-hash: true


### PR DESCRIPTION
Resolves #50 

Use the OpenID Connect (OIDC) standard to publish to PyPI and TestPyPI using PyPI's "Trusted Publisher" implementation to publish without using API tokens stored as GitHub Actions secrets. Use an optional GitHub Actions environment to further restrict publishing to selected branches for additional security.
   - c.f. https://blog.pypi.org/posts/2023-04-20-introducing-trusted-publishers/
   - c.f. https://docs.pypi.org/trusted-publishers/