### PR TITLE
CI: Fix tag serach value for TestPyPI publishing

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -91,7 +91,7 @@ jobs:
       # Publish to TestPyPI on tag events of if manually triggered
       # Compare to 'true' string as booleans get turned into strings in the console
       if: >-
-        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v'))
+        (github.event_name == 'push' && startsWith(github.ref, 'refs/tags'))
         || (github.event_name == 'workflow_dispatch' && github.event.inputs.publish == 'true')
       uses: pypa/gh-action-pypi-publish@v1.8.10
       with:


### PR DESCRIPTION
As the tag events that trigger workflows are not prefixed by 'v' but instead just use SemVer numbers the GitHub Actions `startsWith` function can only check if a tag has been pushed, as `startsWith` does not support regex.
   - c.f. https://docs.github.com/en/actions/learn-github-actions/expressions#startswith

Amends PR #51 (c.f. https://github.com/data-apis/array-api-compat/pull/51/files#r1322311388).