### PR TITLE
MAINT: NumPy normalize_axis_tuple

### DIFF
--- a/array_api_compat/common/_linalg.py
+++ b/array_api_compat/common/_linalg.py
@@ -5,7 +5,11 @@ if TYPE_CHECKING:
     from typing import Literal, Optional, Sequence, Tuple, Union
     from ._typing import ndarray
 
-from numpy.core.numeric import normalize_axis_tuple
+import numpy as np
+if np.__version__[0] == "2":
+    from numpy.lib.array_utils import normalize_axis_tuple
+else:
+    from numpy.core.numeric import normalize_axis_tuple
 
 from ._aliases import matmul, matrix_transpose, tensordot, vecdot
 from .._internal import get_xp


### PR DESCRIPTION
* this function moved from NumPy core to the public API in recent NumPy builds, and is causing
SciPy CI failures here:
https://github.com/scipy/scipy/actions/runs/6555137521/job/17803175138?pr=19402

* normally I'd use PEP440 for this (either vendored or through the appropriate PyPA lib) but maybe you'd prefer to cheat like this on major version vs. more infrastructure?