### PR TITLE
Deprecate using "cpu" as a device for to_device() with CuPy arrays

### DIFF
--- a/array_api_compat/common/_aliases.py
+++ b/array_api_compat/common/_aliases.py
@@ -13,8 +13,14 @@ if TYPE_CHECKING:
 from typing import NamedTuple
 from types import ModuleType
 import inspect
+import sys
 
-from ._helpers import _check_device, is_numpy_array, array_namespace
+from ._helpers import is_numpy_array, array_namespace
+
+def _check_device(xp, device):
+    if xp == sys.modules.get('numpy'):
+        if device not in ["cpu", None]:
+            raise ValueError(f"Unsupported device for NumPy: {device!r}")
 
 # These functions are modified from the NumPy versions.
 

--- a/array_api_compat/common/_helpers.py
+++ b/array_api_compat/common/_helpers.py
@@ -154,11 +154,6 @@ def array_namespace(*xs, api_version=None, _use_compat=True):
 # backwards compatibility alias
 get_namespace = array_namespace
 
-def _check_device(xp, device):
-    if xp == sys.modules.get('numpy'):
-        if device not in ["cpu", None]:
-            raise ValueError(f"Unsupported device for NumPy: {device!r}")
-
 # device() is not on numpy.ndarray and to_device() is not on numpy.ndarray
 # or cupy.ndarray. They are not included in array objects of this library
 # because this library just reuses the respective ndarray classes without

--- a/array_api_compat/common/_helpers.py
+++ b/array_api_compat/common/_helpers.py
@@ -16,6 +16,7 @@ if TYPE_CHECKING:
 import sys
 import math
 import inspect
+import warnings
 
 def is_numpy_array(x):
     # Avoid importing NumPy if it isn't already
@@ -199,7 +200,15 @@ def _cupy_to_device(x, device, /, stream=None):
     elif device == "cpu":
         # allowing us to use `to_device(x, "cpu")`
         # is useful for portable test swapping between
-        # host and device backends
+        # host and device backends. This is deprecated. See
+        # https://github.com/data-apis/array-api-compat/issues/86.
+        # Implementations should prefer using the device keyword to
+        # from_dlpack() (starting from the 2023.12 version of the standard)
+        warnings.warn(
+            "Using `to_device(x, 'cpu')` on CuPy arrays is deprecated. Use the `device` keyword to `from_dlpack()` instead.",
+            DeprecationWarning,
+            stacklevel=3,
+        )
         return x.get()
     elif not isinstance(device, _Device):
         raise ValueError(f"Unsupported device {device!r}")

--- a/array_api_compat/dask/array/_aliases.py
+++ b/array_api_compat/dask/array/_aliases.py
@@ -7,7 +7,6 @@ import numpy as np
 
 from ..._internal import get_xp
 from ...common import _aliases, _linalg
-from ...common._helpers import _check_device
 
 if TYPE_CHECKING:
     from typing import Optional, Tuple, Union
@@ -38,7 +37,6 @@ def dask_arange(
     device: Optional[Device] = None,
     **kwargs,
 ) -> ndarray:
-    _check_device(xp, device)
     args = [start]
     if stop is not None:
         args.append(stop)


### PR DESCRIPTION
See #86 

This should probably not be merged until https://github.com/data-apis/array-api/pull/741 is actually included in a released version of the standard (hopefully 2023.12) and supported by the numpy compat layer.