### PR TITLE
Remove hypothesis pin

### DIFF
--- a/.github/workflows/array-api-tests.yml
+++ b/.github/workflows/array-api-tests.yml
@@ -63,7 +63,6 @@ jobs:
         python -m pip install --upgrade pip
         python -m pip install '${{ inputs.package-name }} ${{ inputs.package-version }}' ${{ inputs.extra-requires }}
         python -m pip install -r ${GITHUB_WORKSPACE}/array-api-tests/requirements.txt
-        python -m pip install hypothesis==6.97.1
     - name: Run the array API testsuite (${{ inputs.package-name }})
       if: "! ((matrix.python-version == '3.11' && inputs.package-name == 'numpy' && contains(inputs.package-version, '1.21')) || (matrix.python-version == '3.8' && inputs.package-name == 'numpy' && contains(inputs.xfails-file-extra, 'dev')))"
       env:


### PR DESCRIPTION
This reverts commit 02059d0d8f025724c08ff757baa6b48a579651ea.

This should no longer be necessary with the latest changes to array-api-tests.