### PR TITLE
Only run the publish to pypi build on tags

### DIFF
--- a/.github/workflows/publish-package.yml
+++ b/.github/workflows/publish-package.yml
@@ -66,7 +66,7 @@ jobs:
 
   publish:
     name: Publish Python distribution to (Test)PyPI
-    if: github.event_name != 'pull_request' && github.repository == 'data-apis/array-api-compat'
+    if: github.event_name != 'pull_request' && github.repository == 'data-apis/array-api-compat' && github.ref_type == 'tag'
     needs: build
     runs-on: ubuntu-latest
     # Mandatory for publishing with a trusted publisher


### PR DESCRIPTION
Otherwise this build "fails" on main leading to a bunch of annoying failed actions checks.