### PR TITLE
Re-enable wrapping unconditionally for NumPy

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -6,7 +6,7 @@ jobs:
     strategy:
       matrix:
         python-version: ['3.9', '3.10', '3.11', '3.12']
-        numpy-version: ['1.21', '1.26', 'dev']
+        numpy-version: ['1.21', '1.26', '2.0', 'dev']
         exclude:
           - python-version: '3.11'
             numpy-version: '1.21'

--- a/array_api_compat/common/_helpers.py
+++ b/array_api_compat/common/_helpers.py
@@ -145,7 +145,7 @@ def is_ndonnx_array(x):
 
     import ndonnx as ndx
 
-    return isinstance(x, ndx.Array)  
+    return isinstance(x, ndx.Array)
 
 def is_dask_array(x):
     """
@@ -340,12 +340,9 @@ def array_namespace(*xs, api_version=None, use_compat=None):
             elif use_compat is False:
                 namespaces.add(np)
             else:
-                # numpy 2.0 has __array_namespace__ and is fully array API
+                # numpy 2.0+ have __array_namespace__, however, they are not yet fully array API
                 # compatible.
-                if hasattr(np.empty(0), '__array_namespace__'):
-                    namespaces.add(np.empty(0).__array_namespace__(api_version=api_version))
-                else:
-                    namespaces.add(numpy_namespace)
+                namespaces.add(numpy_namespace)
         elif is_cupy_array(x):
             if _use_compat:
                 _check_api_version(api_version)

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -4,7 +4,7 @@ import sys
 import pytest
 
 wrapped_libraries = ["numpy", "cupy", "torch", "dask.array"]
-all_libraries = wrapped_libraries + ["jax.numpy", "sparse"]
+all_libraries = wrapped_libraries + ["jax.numpy"]
 
 # `sparse` added array API support as of Python 3.10.
 if sys.version_info >= (3, 10):

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -3,11 +3,8 @@ import sys
 
 import pytest
 
-wrapped_libraries = ["cupy", "torch", "dask.array"]
-all_libraries = wrapped_libraries + ["numpy", "jax.numpy", "sparse"]
-import numpy as np
-if np.__version__[0] == '1':
-    wrapped_libraries.append("numpy")
+wrapped_libraries = ["numpy", "cupy", "torch", "dask.array"]
+all_libraries = wrapped_libraries + ["jax.numpy", "sparse"]
 
 # `sparse` added array API support as of Python 3.10.
 if sys.version_info >= (3, 10):


### PR DESCRIPTION
NumPy 2.0 and 2.1 both have some incompatibilities with the array API (see
#167 and #164).

Closes #168.
