### PR TITLE
Do not merge: try capping the Dask version

### DIFF
--- a/dask-skips.txt
+++ b/dask-skips.txt
@@ -1,2 +1,5 @@
 # slow and not implemented in dask
 array_api_tests/test_linalg.py::test_matrix_power
+
+# hangs on 2024.12
+array_api_tests/test_creation_functions.py::test_eye


### PR DESCRIPTION
Double-check that https://github.com/data-apis/array-api-compat/issues/210 is indeed related to dask 2024.12 release.

I cannot repro gh-210 locally, but on CI recent PRs do hang for hours, so there's something.

EDIT: yes it is. Capping the dask version makes the hang go away. 