### PR TITLE
Bump version to 1.10.0.dev0

### DIFF
--- a/array_api_compat/__init__.py
+++ b/array_api_compat/__init__.py
@@ -17,6 +17,6 @@ to ensure they are not using functionality outside of the standard, but prefer
 this implementation for the default when working with NumPy arrays.
 
 """
-__version__ = '1.9.1'
+__version__ = '1.10.0.dev0'
 
 from .common import *  # noqa: F401, F403


### PR DESCRIPTION
This is needed to work around https://github.com/prefix-dev/pixi/issues/2677.

Without this we can't build array-api-extra against array-api-compat git tip: https://github.com/data-apis/array-api-extra/pull/53#discussion_r1876022501