### PR TITLE
TST: run parameterized tests on more libraries

### DIFF
--- a/array_api_compat/common/_helpers.py
+++ b/array_api_compat/common/_helpers.py
@@ -649,13 +649,9 @@ def device(x: Array, /) -> Device:
         return "cpu"
     elif is_dask_array(x):
         # Peek at the metadata of the jax array to determine type
-        try:
-            import numpy as np
-            if isinstance(x._meta, np.ndarray):
-                # Must be on CPU since backed by numpy
-                return "cpu"
-        except ImportError:
-            pass
+        if is_numpy_array(x._meta):
+            # Must be on CPU since backed by numpy
+            return "cpu"
         return _DASK_DEVICE
     elif is_jax_array(x):
         # JAX has .device() as a method, but it is being deprecated so that it

--- a/docs/supported-array-libraries.md
+++ b/docs/supported-array-libraries.md
@@ -137,3 +137,8 @@ The minimum supported Dask version is 2023.12.0.
 ## [Sparse](https://sparse.pydata.org/en/stable/)
 
 Similar to JAX, `sparse` Array API support is contained directly in `sparse`.
+
+(array-api-strict-support)=
+## [array-api-strict](https://data-apis.org/array-api-strict/)
+
+array-api-strict exists only to test support for the Array API, so it does not need any wrappers.

--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -1,14 +1,10 @@
 from importlib import import_module
-import sys
 
 import pytest
 
 wrapped_libraries = ["numpy", "cupy", "torch", "dask.array"]
-all_libraries = wrapped_libraries + ["jax.numpy"]
+all_libraries = wrapped_libraries + ["array_api_strict", "jax.numpy", "sparse"]
 
-# `sparse` added array API support as of Python 3.10.
-if sys.version_info >= (3, 10):
-    all_libraries.append('sparse')
 
 def import_(library, wrapper=False):
     if library == 'cupy':
@@ -20,9 +16,7 @@ def import_(library, wrapper=False):
             jax_numpy = import_module("jax.numpy")
             if not hasattr(jax_numpy, "__array_api_version__"):
                 library = 'jax.experimental.array_api'
-        elif library.startswith('sparse'):
-            library = 'sparse'
-        else:
+        elif library in wrapped_libraries:
             library = 'array_api_compat.' + library
 
     return import_module(library)

--- a/tests/test_all.py
+++ b/tests/test_all.py
@@ -18,7 +18,10 @@ import pytest
 
 @pytest.mark.parametrize("library", ["common"] + wrapped_libraries)
 def test_all(library):
-    import_(library, wrapper=True)
+    if library == "common":
+        import array_api_compat.common  # noqa: F401
+    else:
+        import_(library, wrapper=True)
 
     for mod_name in sys.modules:
         if not mod_name.startswith('array_api_compat.' + library):

--- a/tests/test_array_namespace.py
+++ b/tests/test_array_namespace.py
@@ -14,12 +14,12 @@ from ._helpers import import_, all_libraries, wrapped_libraries
 
 @pytest.mark.parametrize("use_compat", [True, False, None])
 @pytest.mark.parametrize("api_version", [None, "2021.12", "2022.12", "2023.12"])
-@pytest.mark.parametrize("library", all_libraries + ['array_api_strict'])
+@pytest.mark.parametrize("library", all_libraries)
 def test_array_namespace(library, api_version, use_compat):
     xp = import_(library)
 
     array = xp.asarray([1.0, 2.0, 3.0])
-    if use_compat is True and library in {'array_api_strict', 'jax.numpy', 'sparse'}:
+    if use_compat and library not in wrapped_libraries:
         pytest.raises(ValueError, lambda: array_namespace(array, use_compat=use_compat))
         return
     namespace = array_api_compat.array_namespace(array, api_version=api_version, use_compat=use_compat)


### PR DESCRIPTION
- Add array-api-strict and sparse to several parameterized tests
- Add array-api-strict to the documentation
- Detect and xfail more bugs in cross-library `asarray()`
- Follow-up: #232 

**Q:**  (out of scope) shouldn't we add an `is_array_api_strict_array` function, to match `is_array_api_strict_namespace`?