### PR TITLE
ENH: size() to return None on dask instead of nan

### DIFF
--- a/array_api_compat/common/_helpers.py
+++ b/array_api_compat/common/_helpers.py
@@ -788,19 +788,24 @@ def to_device(x: Array, device: Device, /, *, stream: Optional[Union[int, Any]] 
     return x.to_device(device, stream=stream)
 
 
-def size(x):
+def size(x: Array) -> int | None:
     """
     Return the total number of elements of x.
 
     This is equivalent to `x.size` according to the `standard
     <https://data-apis.org/array-api/latest/API_specification/generated/array_api.array.size.html>`__.
+
     This helper is included because PyTorch defines `size` in an
     :external+torch:meth:`incompatible way <torch.Tensor.size>`.
-
+    It also fixes dask.array's behaviour which returns nan for unknown sizes, whereas
+    the standard requires None.
     """
+    # Lazy API compliant arrays, such as ndonnx, can contain None in their shape
     if None in x.shape:
         return None
-    return math.prod(x.shape)
+    out = math.prod(x.shape)
+    # dask.array.Array.shape can contain NaN
+    return None if math.isnan(out) else out
 
 
 def is_writeable_array(x) -> bool:


### PR DESCRIPTION
dask arrays of unknown shape return NaN in their `.size` and `.shape` properties. This was chosen a long time before the Array API standard existed, but alas diverges from the array API standard itself:

- https://data-apis.org/array-api/latest/API_specification/generated/array_api.array.size.html
- https://data-apis.org/array-api/latest/API_specification/generated/array_api.array.shape.html

ndonnx, another library which can have arrays of unknown shape, uses None instead.

This PR changes the `size()` function to make dask conform to the standard and adds units tests which were previously missing.

**Q:** Should we add a `shape()` function to cover for Dask's `.shape` property non-standard behaviour?