### PR TITLE
TST: da.arange fails for args near 2**63

### DIFF
--- a/dask-xfails.txt
+++ b/dask-xfails.txt
@@ -31,6 +31,9 @@ array_api_tests/test_set_functions.py::test_unique_values
 # fails for ndim > 2
 array_api_tests/test_linalg.py::test_svdvals
 
+# dtype mismatch got uint64, but should be uint8, NPY_PROMOTION_STATE=weak doesn't help :(
+array_api_tests/test_linalg.py::test_tensordot
+
 # AssertionError: out.dtype=uint64, but should be uint8 [tensordot(uint8, uint8)]
 array_api_tests/test_linalg.py::test_linalg_tensordot
 

--- a/dask-xfails.txt
+++ b/dask-xfails.txt
@@ -7,6 +7,10 @@ array_api_tests/test_creation_functions.py::test_eye
 # finfo(float32).eps returns float32 but should return float
 array_api_tests/test_data_type_functions.py::test_finfo[float32]
 
+# out[-1]=dask.array<getitem ...> but should be some floating number
+# (I think the test is not forcing the op to be computed?)
+array_api_tests/test_creation_functions.py::test_linspace
+
 # Array methods and attributes not already on da.Array cannot be wrapped
 array_api_tests/test_has_names.py::test_has_names[array_method-__array_namespace__]
 array_api_tests/test_has_names.py::test_has_names[array_method-to_device]

--- a/dask-xfails.txt
+++ b/dask-xfails.txt
@@ -27,6 +27,9 @@ array_api_tests/test_set_functions.py::test_unique_values
 # fails for ndim > 2
 array_api_tests/test_linalg.py::test_svdvals
 
+# AssertionError: out.dtype=uint64, but should be uint8 [tensordot(uint8, uint8)]
+array_api_tests/test_linalg.py::test_linalg_tensordot
+
 # ZeroDivisionError in dask's normalize_chunks/auto_chunks internals
 array_api_tests/test_linalg.py::test_inv
 array_api_tests/test_linalg.py::test_matrix_power
@@ -39,6 +42,7 @@ array_api_tests/test_signatures.py::test_extension_func_signature[linalg.eigvals
 array_api_tests/test_signatures.py::test_extension_func_signature[linalg.matrix_power]
 array_api_tests/test_signatures.py::test_extension_func_signature[linalg.pinv]
 array_api_tests/test_signatures.py::test_extension_func_signature[linalg.slogdet]
+array_api_tests/test_linalg.py::test_cross
 array_api_tests/test_linalg.py::test_det
 array_api_tests/test_linalg.py::test_eigh
 array_api_tests/test_linalg.py::test_eigvalsh

--- a/dask-xfails.txt
+++ b/dask-xfails.txt
@@ -1,25 +1,3 @@
-# This fails in dask
-# import dask.array as da
-# a = da.array([1]).reshape((1,1))
-# key = (0, slice(None, None, -1))
-# a[key] = da.array([1])
-
-# Failing hypothesis test case
-#x=dask.array<zeros_like, shape=(0, 2), dtype=bool, chunksize=(0, 2), chunktype=numpy.ndarray>
-#| Draw 1 (key): (slice(None, None, None), slice(None, None, None))
-#| Draw 2 (value): dask.array<zeros_like, shape=(0, 2), dtype=bool, chunksize=(0, 2), chunktype=numpy.ndarray>
-
-# Various shape mismatches e.g.
-ValueError: shape mismatch: value array of shape (0, 2) could not be broadcast to indexing result of shape (0, 2)
-array_api_tests/test_array_object.py::test_setitem
-
-# Fails since bad upcast from uint8 -> int64
-# MRE:
-# a = da.array(0, dtype="uint8")
-# b = da.array(False)
-# a[b] = 0
-array_api_tests/test_array_object.py::test_setitem_masking
-
 # Various indexing errors
 array_api_tests/test_array_object.py::test_getitem_masking
 
@@ -28,21 +6,6 @@ array_api_tests/test_creation_functions.py::test_eye
 
 # finfo(float32).eps returns float32 but should return float
 array_api_tests/test_data_type_functions.py::test_finfo[float32]
-
-# out[-1]=dask.array<getitem ...> but should be some floating number
-# (I think the test is not forcing the op to be computed?)
-array_api_tests/test_creation_functions.py::test_linspace
-
-# out.shape=(2,) but should be (1,)
-array_api_tests/test_indexing_functions.py::test_take
-
-# out=-0, but should be +0
-array_api_tests/test_special_cases.py::test_binary[__pow__(x1_i is -0 and x2_i > 0 and not (x2_i.is_integer() and x2_i % 2 == 1)) -> +0]
-array_api_tests/test_special_cases.py::test_iop[__ipow__(x1_i is -0 and x2_i > 0 and not (x2_i.is_integer() and x2_i % 2 == 1)) -> +0]
-
-# output is nan but should be infinity
-array_api_tests/test_special_cases.py::test_iop[__ipow__(x1_i is -infinity and x2_i > 0 and not (x2_i.is_integer() and x2_i % 2 == 1)) -> +infinity]
-array_api_tests/test_special_cases.py::test_binary[__pow__(x1_i is -infinity and x2_i > 0 and not (x2_i.is_integer() and x2_i % 2 == 1)) -> +infinity]
 
 # Array methods and attributes not already on da.Array cannot be wrapped
 array_api_tests/test_has_names.py::test_has_names[array_method-__array_namespace__]
@@ -63,24 +26,10 @@ array_api_tests/test_set_functions.py::test_unique_values
 
 # fails for ndim > 2
 array_api_tests/test_linalg.py::test_svdvals
-array_api_tests/test_linalg.py::test_cholesky
-
-# dtype mismatch got uint64, but should be uint8, NPY_PROMOTION_STATE=weak doesn't help :(
-array_api_tests/test_linalg.py::test_tensordot
-
-# AssertionError: out.dtype=uint64, but should be uint8 [tensordot(uint8, uint8)]
-array_api_tests/test_linalg.py::test_linalg_tensordot
-
-# AssertionError: out.shape=(1,), but should be () [linalg.vector_norm(keepdims=True)]
-array_api_tests/test_linalg.py::test_vector_norm
 
 # ZeroDivisionError in dask's normalize_chunks/auto_chunks internals
 array_api_tests/test_linalg.py::test_inv
 array_api_tests/test_linalg.py::test_matrix_power
-
-# did not raise error for invalid shapes
-array_api_tests/test_linalg.py::test_matmul
-array_api_tests/test_linalg.py::test_linalg_matmul
 
 # Linalg - these don't exist in dask
 array_api_tests/test_signatures.py::test_extension_func_signature[linalg.cross]
@@ -90,11 +39,9 @@ array_api_tests/test_signatures.py::test_extension_func_signature[linalg.eigvals
 array_api_tests/test_signatures.py::test_extension_func_signature[linalg.matrix_power]
 array_api_tests/test_signatures.py::test_extension_func_signature[linalg.pinv]
 array_api_tests/test_signatures.py::test_extension_func_signature[linalg.slogdet]
-array_api_tests/test_linalg.py::test_cross
 array_api_tests/test_linalg.py::test_det
 array_api_tests/test_linalg.py::test_eigh
 array_api_tests/test_linalg.py::test_eigvalsh
-array_api_tests/test_linalg.py::test_matrix_norm
 array_api_tests/test_linalg.py::test_matrix_rank
 array_api_tests/test_linalg.py::test_pinv
 array_api_tests/test_linalg.py::test_slogdet
@@ -106,14 +53,10 @@ array_api_tests/test_has_names.py::test_has_names[linalg-matrix_power]
 array_api_tests/test_has_names.py::test_has_names[linalg-pinv]
 array_api_tests/test_has_names.py::test_has_names[linalg-slogdet]
 
-# missing mode kw
-# https://github.com/dask/dask/issues/10388
-array_api_tests/test_linalg.py::test_qr
-
 # Constructing the input arrays fails to a weird shape error...
 array_api_tests/test_linalg.py::test_solve
 
-# missing full_matrics kw
+# missing full_matrices kw
 # https://github.com/dask/dask/issues/10389
 # also only supports 2-d inputs
 array_api_tests/test_linalg.py::test_svd
@@ -128,17 +71,12 @@ array_api_tests/test_has_names.py::test_has_names[creation-from_dlpack]
 array_api_tests/test_has_names.py::test_has_names[array_method-__dlpack__]
 array_api_tests/test_has_names.py::test_has_names[array_method-__dlpack_device__]
 
-# Some cases unsupported by dask
-array_api_tests/test_manipulation_functions.py::test_roll
-
 # No mT on dask array
 array_api_tests/meta/test_hypothesis_helpers.py::test_symmetric_matrices
 
-# The test suite is incorrectly checking sums that have loss of significance
-# (https://github.com/data-apis/array-api-tests/issues/168)
-array_api_tests/test_statistical_functions.py::test_sum
-array_api_tests/test_statistical_functions.py::test_prod
+# Edge case of args near 2**63
+# https://github.com/dask/dask/issues/11706
+array_api_tests/test_creation_functions.py::test_arange
 
 # 2023.12 support
 array_api_tests/test_manipulation_functions.py::test_repeat
-array_api_tests/test_searching_functions.py::test_searchsorted


### PR DESCRIPTION
https://github.com/dask/dask/issues/11706

Closes https://github.com/data-apis/array-api-tests/issues/338

Also clean up a wealth of XPASS