### PR TITLE
Annotate array_namespace and add py.typed

### DIFF
--- a/array_api_compat/common/_helpers.py
+++ b/array_api_compat/common/_helpers.py
@@ -11,7 +11,7 @@ from typing import TYPE_CHECKING
 
 if TYPE_CHECKING:
     from typing import Optional, Union, Any
-    from ._typing import Array, Device
+    from ._typing import Array, Device, Namespace
 
 import sys
 import math
@@ -439,7 +439,7 @@ def _check_api_version(api_version: str) -> None:
         raise ValueError("Only the 2023.12 version of the array API specification is currently supported")
 
 
-def array_namespace(*xs, api_version=None, use_compat=None):
+def array_namespace(*xs, api_version=None, use_compat=None) -> Namespace:
     """
     Get the array API compatible namespace for the arrays `xs`.
 

--- a/array_api_compat/common/_typing.py
+++ b/array_api_compat/common/_typing.py
@@ -5,6 +5,7 @@ __all__ = [
     "SupportsBufferProtocol",
 ]
 
+from types import ModuleType
 from typing import (
     Any,
     TypeVar,
@@ -22,3 +23,4 @@ SupportsBufferProtocol = Any
 Array = Any
 Device = Any
 DType = Any
+Namespace = ModuleType

--- a/setup.py
+++ b/setup.py
@@ -34,4 +34,7 @@ setup(
         "License :: OSI Approved :: MIT License",
         "Operating System :: OS Independent",
     ],
+    package_data={
+        "array_api_compat": ["py.typed"],
+    },
 )


### PR DESCRIPTION
This appears to be the only missing type annotation in the project.