### PR TITLE
TST: run tests without all libraries installed

### DIFF
--- a/tests/_helpers.py
+++ b/tests/_helpers.py
@@ -8,8 +8,7 @@ all_libraries = wrapped_libraries + [
 ]
 
 def import_(library, wrapper=False):
-    if library in ('cupy', 'ndonnx'):
-        pytest.importorskip(library)
+    pytest.importorskip(library)
     if wrapper:
         if 'jax' in library:
             # JAX v0.4.32 implements the array API directly in jax.numpy


### PR DESCRIPTION
Crucially, without this it's impossible to run on numpy 2.2, as sparse pins it to <=2.0