### PR TITLE
add torch xfails for scalars in binary functions

### DIFF
--- a/torch-xfails.txt
+++ b/torch-xfails.txt
@@ -124,7 +124,6 @@ array_api_tests/test_signatures.py::test_func_signature[from_dlpack]
 # Argument 'max_version' missing from signature
 array_api_tests/test_signatures.py::test_array_method_signature[__dlpack__]
 
-
 # 2024.12 support
 array_api_tests/test_signatures.py::test_func_signature[bitwise_and]
 array_api_tests/test_signatures.py::test_func_signature[bitwise_left_shift]
@@ -136,3 +135,22 @@ array_api_tests/test_signatures.py::test_array_method_signature[__lshift__]
 array_api_tests/test_signatures.py::test_array_method_signature[__or__]
 array_api_tests/test_signatures.py::test_array_method_signature[__rshift__]
 array_api_tests/test_signatures.py::test_array_method_signature[__xor__]
+
+# 2024.12 support: binary functions reject python scalar arguments
+array_api_tests/test_operators_and_elementwise_functions.py::test_binary_with_scalars_real[atan2]
+array_api_tests/test_operators_and_elementwise_functions.py::test_binary_with_scalars_real[copysign]
+array_api_tests/test_operators_and_elementwise_functions.py::test_binary_with_scalars_real[divide]
+array_api_tests/test_operators_and_elementwise_functions.py::test_binary_with_scalars_real[hypot]
+array_api_tests/test_operators_and_elementwise_functions.py::test_binary_with_scalars_real[logaddexp]
+array_api_tests/test_operators_and_elementwise_functions.py::test_binary_with_scalars_real[maximum]
+array_api_tests/test_operators_and_elementwise_functions.py::test_binary_with_scalars_real[minimum]
+array_api_tests/test_operators_and_elementwise_functions.py::test_binary_with_scalars_real[equal]
+array_api_tests/test_operators_and_elementwise_functions.py::test_binary_with_scalars_real[neq]
+array_api_tests/test_operators_and_elementwise_functions.py::test_binary_with_scalars_real[less]
+array_api_tests/test_operators_and_elementwise_functions.py::test_binary_with_scalars_real[les_equal]
+array_api_tests/test_operators_and_elementwise_functions.py::test_binary_with_scalars_real[greater]
+array_api_tests/test_operators_and_elementwise_functions.py::test_binary_with_scalars_real[greater_equal]
+
+array_api_tests/test_operators_and_elementwise_functions.py::test_binary_with_scalars_bool[logical_and]
+array_api_tests/test_operators_and_elementwise_functions.py::test_binary_with_scalars_bool[logical_or]
+array_api_tests/test_operators_and_elementwise_functions.py::test_binary_with_scalars_bool[logical_xor]


### PR DESCRIPTION
Update the xfail listing with functions from https://github.com/data-apis/array-api-tests/pull/348