### PR TITLE
CI: run array-api-tests for torch f64 default

### DIFF
--- a/.github/workflows/array-api-tests-torch-f64.yml
+++ b/.github/workflows/array-api-tests-torch-f64.yml
@@ -1,0 +1,12 @@
+name: Array API Tests (F64 PyTorch Latest)
+
+on: [push, pull_request]
+
+jobs:
+  array-api-tests-torch:
+    uses: ./.github/workflows/array-api-tests.yml
+    with:
+      package-name: torch
+      extra-env-vars: |
+        ARRAY_API_TESTS_SKIP_DTYPES=uint16,uint32,uint64
+        ARRAY_API_TESTS_MODULE="exec('import array_api_compat.torch as xp; import torch; torch.set_default_dtype(xp.float64)')"


### PR DESCRIPTION
so that there's a chance to catch things like gh-273