### PR TITLE
Fix clipping float dtypes when either min or max are Python ints

### DIFF
--- a/array_api_compat/common/_aliases.py
+++ b/array_api_compat/common/_aliases.py
@@ -363,10 +363,11 @@ def clip(
 
     # At least handle the case of Python integers correctly (see
     # https://github.com/numpy/numpy/pull/26892).
-    if type(min) is int and min <= wrapped_xp.iinfo(x.dtype).min:
-        min = None
-    if type(max) is int and max >= wrapped_xp.iinfo(x.dtype).max:
-        max = None
+    if wrapped_xp.isdtype(x.dtype, "integral"):
+        if type(min) is int and min <= wrapped_xp.iinfo(x.dtype).min:
+            min = None
+        if type(max) is int and max >= wrapped_xp.iinfo(x.dtype).max:
+            max = None
 
     dev = device(x)
     if out is None:


### PR DESCRIPTION
This PR makes `clip` no longer crash when `x` has a floating point dtype and `min` and/or `max` are Python `int`s.

```python
import array_api_compat.numpy as xp
xp.clip(xp.asarray(0.0), 0, 1)  # <- this used to crash
```

The [Array API for `clip` states that behavior is unspecified if `x`and either `min` or `max` have different data type kinds](https://data-apis.org/array-api/2024.12/API_specification/generated/array_api.clip.html), but I think the change in this PR makes it behave more like what one might expect. [This change also makes the code more similar to NumPy's handling of Python `int`s in `clip`.](https://github.com/numpy/numpy/blob/main/numpy/_core/_methods.py#L100)

This is my first PR for this repo, hopefully I got it right :) Let me know if I should add anything else.
The work you do with array-api is great, thanks a lot!