### PR TITLE
Add a CuPy xfail

### DIFF
--- a/cupy-xfails.txt
+++ b/cupy-xfails.txt
@@ -183,7 +183,7 @@ array_api_tests/test_manipulation_functions.py::test_repeat
 array_api_tests/test_signatures.py::test_func_signature[from_dlpack]
 array_api_tests/test_signatures.py::test_array_method_signature[__dlpack__]
 
-+# 2024.12 support
+# 2024.12 support
 array_api_tests/test_signatures.py::test_func_signature[count_nonzero]
 array_api_tests/test_signatures.py::test_func_signature[bitwise_and]
 array_api_tests/test_signatures.py::test_func_signature[bitwise_left_shift]
@@ -192,3 +192,5 @@ array_api_tests/test_signatures.py::test_func_signature[bitwise_right_shift]
 array_api_tests/test_signatures.py::test_func_signature[bitwise_xor]
 array_api_tests/test_special_cases.py::test_binary[nextafter(x1_i is +0 and x2_i is -0) -> -0]
 
+# cupy 13.x follows numpy 1.x w/o weak promotion: result_type(int32, uint8, 1) != result_type(int32, uint8)
+array_api_tests/test_data_type_functions.py::TestResultType::test_with_scalars


### PR DESCRIPTION
CuPy 13.x follows NumPy 1.x without "weak scalars". In NumPy `result_type(int32, uint8, 1) != result_type(int32, uint8)` has been fixed in 2.x (or 1.x with set_promotion_state("weak"), so hopefully CuPy 14.x follows the suite, when released.

Until then, just xfail the test.