### PR TITLE
CuPy multi-device support

### DIFF
--- a/array_api_compat/common/_aliases.py
+++ b/array_api_compat/common/_aliases.py
@@ -7,12 +7,12 @@ from __future__ import annotations
 import inspect
 from typing import NamedTuple, Optional, Sequence, Tuple, Union
 
-from ._helpers import array_namespace, _check_device, device, is_cupy_namespace
+from ._helpers import array_namespace, device, is_cupy_namespace, _device_ctx
 from ._typing import Array, Device, DType, Namespace
 
 # These functions are modified from the NumPy versions.
 
-# Creation functions add the device keyword (which does nothing for NumPy)
+# Creation functions add the device keyword (which does nothing for NumPy and Dask)
 
 def arange(
     start: Union[int, float],
@@ -25,8 +25,8 @@ def arange(
     device: Optional[Device] = None,
     **kwargs,
 ) -> Array:
-    _check_device(xp, device)
-    return xp.arange(start, stop=stop, step=step, dtype=dtype, **kwargs)
+    with _device_ctx(xp, device):
+        return xp.arange(start, stop=stop, step=step, dtype=dtype, **kwargs)
 
 def empty(
     shape: Union[int, Tuple[int, ...]],
@@ -36,8 +36,8 @@ def empty(
     device: Optional[Device] = None,
     **kwargs,
 ) -> Array:
-    _check_device(xp, device)
-    return xp.empty(shape, dtype=dtype, **kwargs)
+    with _device_ctx(xp, device):
+        return xp.empty(shape, dtype=dtype, **kwargs)
 
 def empty_like(
     x: Array,
@@ -48,8 +48,8 @@ def empty_like(
     device: Optional[Device] = None,
     **kwargs,
 ) -> Array:
-    _check_device(xp, device)
-    return xp.empty_like(x, dtype=dtype, **kwargs)
+    with _device_ctx(xp, device, like=x):
+        return xp.empty_like(x, dtype=dtype, **kwargs)
 
 def eye(
     n_rows: int,
@@ -62,8 +62,8 @@ def eye(
     device: Optional[Device] = None,
     **kwargs,
 ) -> Array:
-    _check_device(xp, device)
-    return xp.eye(n_rows, M=n_cols, k=k, dtype=dtype, **kwargs)
+    with _device_ctx(xp, device):
+        return xp.eye(n_rows, M=n_cols, k=k, dtype=dtype, **kwargs)
 
 def full(
     shape: Union[int, Tuple[int, ...]],
@@ -74,8 +74,8 @@ def full(
     device: Optional[Device] = None,
     **kwargs,
 ) -> Array:
-    _check_device(xp, device)
-    return xp.full(shape, fill_value, dtype=dtype, **kwargs)
+    with _device_ctx(xp, device):
+        return xp.full(shape, fill_value, dtype=dtype, **kwargs)
 
 def full_like(
     x: Array,
@@ -87,8 +87,8 @@ def full_like(
     device: Optional[Device] = None,
     **kwargs,
 ) -> Array:
-    _check_device(xp, device)
-    return xp.full_like(x, fill_value, dtype=dtype, **kwargs)
+    with _device_ctx(xp, device, like=x):
+        return xp.full_like(x, fill_value, dtype=dtype, **kwargs)
 
 def linspace(
     start: Union[int, float],
@@ -102,8 +102,8 @@ def linspace(
     endpoint: bool = True,
     **kwargs,
 ) -> Array:
-    _check_device(xp, device)
-    return xp.linspace(start, stop, num, dtype=dtype, endpoint=endpoint, **kwargs)
+    with _device_ctx(xp, device):
+        return xp.linspace(start, stop, num, dtype=dtype, endpoint=endpoint, **kwargs)
 
 def ones(
     shape: Union[int, Tuple[int, ...]],
@@ -113,8 +113,8 @@ def ones(
     device: Optional[Device] = None,
     **kwargs,
 ) -> Array:
-    _check_device(xp, device)
-    return xp.ones(shape, dtype=dtype, **kwargs)
+    with _device_ctx(xp, device):
+        return xp.ones(shape, dtype=dtype, **kwargs)
 
 def ones_like(
     x: Array,
@@ -125,8 +125,8 @@ def ones_like(
     device: Optional[Device] = None,
     **kwargs,
 ) -> Array:
-    _check_device(xp, device)
-    return xp.ones_like(x, dtype=dtype, **kwargs)
+    with _device_ctx(xp, device, like=x):
+        return xp.ones_like(x, dtype=dtype, **kwargs)
 
 def zeros(
     shape: Union[int, Tuple[int, ...]],
@@ -136,8 +136,8 @@ def zeros(
     device: Optional[Device] = None,
     **kwargs,
 ) -> Array:
-    _check_device(xp, device)
-    return xp.zeros(shape, dtype=dtype, **kwargs)
+    with _device_ctx(xp, device):
+        return xp.zeros(shape, dtype=dtype, **kwargs)
 
 def zeros_like(
     x: Array,
@@ -148,8 +148,8 @@ def zeros_like(
     device: Optional[Device] = None,
     **kwargs,
 ) -> Array:
-    _check_device(xp, device)
-    return xp.zeros_like(x, dtype=dtype, **kwargs)
+    with _device_ctx(xp, device, like=x):
+        return xp.zeros_like(x, dtype=dtype, **kwargs)
 
 # np.unique() is split into four functions in the array API:
 # unique_all, unique_counts, unique_inverse, and unique_values (this is done

--- a/array_api_compat/common/_helpers.py
+++ b/array_api_compat/common/_helpers.py
@@ -7,10 +7,13 @@ users of the compat library.
 """
 from __future__ import annotations
 
+import contextlib
 import sys
 import math
 import inspect
 import warnings
+from collections.abc import Generator
+from types import ModuleType
 from typing import Optional, Union, Any
 
 from ._typing import Array, Device, Namespace
@@ -595,10 +598,6 @@ def array_namespace(
 # backwards compatibility alias
 get_namespace = array_namespace
 
-def _check_device(xp, device):
-    if xp == sys.modules.get('numpy'):
-        if device not in ["cpu", None]:
-            raise ValueError(f"Unsupported device for NumPy: {device!r}")
 
 # Placeholder object to represent the dask device
 # when the array backend is not the CPU.
@@ -608,6 +607,7 @@ class _dask_device:
         return "DASK_DEVICE"
 
 _DASK_DEVICE = _dask_device()
+
 
 # device() is not on numpy.ndarray or dask.array and to_device() is not on numpy.ndarray
 # or cupy.ndarray. They are not included in array objects of this library
@@ -685,49 +685,38 @@ def device(x: Array, /) -> Device:
 # Prevent shadowing, used below
 _device = device
 
+
 # Based on cupy.array_api.Array.to_device
 def _cupy_to_device(x, device, /, stream=None):
     import cupy as cp
-    from cupy.cuda import Device as _Device
-    from cupy.cuda import stream as stream_module
-    from cupy_backends.cuda.api import runtime
 
-    if device == x.device:
-        return x
-    elif device == "cpu":
+    if device == "cpu":
         # allowing us to use `to_device(x, "cpu")`
         # is useful for portable test swapping between
         # host and device backends
         return x.get()
-    elif not isinstance(device, _Device):
-        raise ValueError(f"Unsupported device {device!r}")
-    else:
-        # see cupy/cupy#5985 for the reason how we handle device/stream here
-        prev_device = runtime.getDevice()
-        prev_stream: stream_module.Stream = None
-        if stream is not None:
-            prev_stream = stream_module.get_current_stream()
-            # stream can be an int as specified in __dlpack__, or a CuPy stream
-            if isinstance(stream, int):
-                stream = cp.cuda.ExternalStream(stream)
-            elif isinstance(stream, cp.cuda.Stream):
-                pass
-            else:
-                raise ValueError('the input stream is not recognized')
-            stream.use()
-        try:
-            runtime.setDevice(device.id)
-            arr = x.copy()
-        finally:
-            runtime.setDevice(prev_device)
-            if stream is not None:
-                prev_stream.use()
-        return arr
+    if not isinstance(device, cp.cuda.Device):
+        raise TypeError(f"Unsupported device {device!r}")
+
+    # see cupy/cupy#5985 for the reason how we handle device/stream here
+
+    # stream can be an int as specified in __dlpack__, or a CuPy stream
+    if isinstance(stream, int):
+        stream = cp.cuda.ExternalStream(stream)
+    elif stream is None:
+        stream = contextlib.nullcontext()
+    elif not isinstance(stream, cp.cuda.Stream):
+        raise TypeError('the input stream is not recognized')
+
+    with device, stream:
+        return cp.asarray(x)
+
 
 def _torch_to_device(x, device, /, stream=None):
     if stream is not None:
         raise NotImplementedError
     return x.to(device)
+
 
 def to_device(x: Array, device: Device, /, *, stream: Optional[Union[int, Any]] = None) -> Array:
     """
@@ -809,6 +798,43 @@ def to_device(x: Array, device: Device, /, *, stream: Optional[Union[int, Any]] 
         # device is same instead of err-ing.
         return x
     return x.to_device(device, stream=stream)
+
+
+def _device_ctx(
+    bare_xp: ModuleType, device: Device, like: Array | None = None
+) -> Generator[None]:
+    """Context manager which changes the current device in CuPy.
+    
+    Used internally by array creation functions in common._aliases.
+    """
+    if device is None:
+        if like is None:
+            return contextlib.nullcontext()    
+        device = _device(like)
+
+    if bare_xp is sys.modules.get('numpy'):
+        if device != "cpu":
+            raise ValueError(f"Unsupported device for NumPy: {device!r}")
+        return contextlib.nullcontext()
+
+    if bare_xp is sys.modules.get('dask.array'):
+        if device not in ("cpu", _DASK_DEVICE):
+            raise ValueError(f"Unsupported device for Dask: {device!r}")
+        return contextlib.nullcontext()
+
+    if bare_xp is sys.modules.get('cupy'):
+        if not isinstance(device, bare_xp.cuda.Device):
+            raise TypeError(f"device is not a cupy.cuda.Device: {device!r}")
+        return device
+
+    # PyTorch doesn't have a "current device" context manager and you
+    # can't use array creation functions from common._aliases.
+    raise AssertionError("unreachable")  # pragma: nocover
+
+
+def _validate_device(bare_xp: ModuleType, device: Device) -> None:
+    with _device_ctx(bare_xp, device):
+        pass
 
 
 def size(x: Array) -> int | None:

--- a/array_api_compat/cupy/_aliases.py
+++ b/array_api_compat/cupy/_aliases.py
@@ -62,8 +62,6 @@ matrix_transpose = get_xp(cp)(_aliases.matrix_transpose)
 tensordot = get_xp(cp)(_aliases.tensordot)
 sign = get_xp(cp)(_aliases.sign)
 
-_copy_default = object()
-
 
 # asarray also adds the copy keyword, which is not present in numpy 1.0.
 def asarray(
@@ -74,7 +72,7 @@ def asarray(
     *,
     dtype: Optional[DType] = None,
     device: Optional[Device] = None,
-    copy: Optional[bool] = _copy_default,
+    copy: Optional[bool] = None,
     **kwargs,
 ) -> Array:
     """
@@ -83,26 +81,14 @@ def asarray(
     See the corresponding documentation in the array library and/or the array API
     specification for more details.
     """
-    with cp.cuda.Device(device):
-        # cupy is like NumPy 1.26 (except without _CopyMode). See the comments
-        # in asarray in numpy/_aliases.py.
-        if copy is not _copy_default:
-            # A future version of CuPy will change the meaning of copy=False
-            # to mean no-copy. We don't know for certain what version it will
-            # be yet, so to avoid breaking that version, we use a different
-            # default value for copy so asarray(obj) with no copy kwarg will
-            # always do the copy-if-needed behavior.
+    if copy is False:
+        raise NotImplementedError("asarray(copy=False) is not yet supported in cupy")
 
-            # This will still need to be updated to remove the
-            # NotImplementedError for copy=False, but at least this won't
-            # break the default or existing behavior.
-            if copy is None:
-                copy = False
-            elif copy is False:
-                raise NotImplementedError("asarray(copy=False) is not yet supported in cupy")
-            kwargs['copy'] = copy
-
-        return cp.array(obj, dtype=dtype, **kwargs)
+    with _helpers._device_ctx(cp, device):
+        if copy is None:
+            return cp.asarray(obj, dtype=dtype, **kwargs)
+        else:
+            return cp.array(obj, dtype=dtype, copy=True, **kwargs)
 
 
 def astype(

--- a/array_api_compat/cupy/_info.py
+++ b/array_api_compat/cupy/_info.py
@@ -26,6 +26,7 @@ from cupy import (
     complex128,
 )
 
+
 class __array_namespace_info__:
     """
     Get the array API inspection namespace for CuPy.
@@ -117,7 +118,7 @@ class __array_namespace_info__:
 
         Returns
         -------
-        device : str
+        device : Device
             The default device used for new CuPy arrays.
 
         Examples
@@ -126,6 +127,15 @@ class __array_namespace_info__:
         >>> info.default_device()
         Device(0)
 
+        Notes
+        -----
+        This method returns the static default device when CuPy is initialized.
+        However, the *current* device used by creation functions (``empty`` etc.)
+        can be changed globally or with a context manager.
+
+        See Also
+        --------
+        https://github.com/data-apis/array-api/issues/835
         """
         return cuda.Device(0)
 
@@ -312,7 +322,7 @@ class __array_namespace_info__:
 
         Returns
         -------
-        devices : list of str
+        devices : list[Device]
             The devices supported by CuPy.
 
         See Also

--- a/array_api_compat/dask/array/_aliases.py
+++ b/array_api_compat/dask/array/_aliases.py
@@ -25,7 +25,7 @@ from numpy import (
 )
 import dask.array as da
 
-from ...common import _aliases, array_namespace
+from ...common import _aliases, _helpers, array_namespace
 from ...common._typing import (
     Array,
     Device,
@@ -56,6 +56,7 @@ def astype(
     specification for more details.
     """
     # TODO: respect device keyword?
+    _helpers._validate_device(da, device)
 
     if not copy and dtype == x.dtype:
         return x
@@ -86,6 +87,7 @@ def arange(
     specification for more details.
     """
     # TODO: respect device keyword?
+    _helpers._validate_device(da, device)
 
     args = [start]
     if stop is not None:
@@ -152,6 +154,7 @@ def asarray(
     specification for more details.
     """
     # TODO: respect device keyword?
+    _helpers._validate_device(da, device)
 
     if isinstance(obj, da.Array):
         if dtype is not None and dtype != obj.dtype:

--- a/array_api_compat/dask/array/_info.py
+++ b/array_api_compat/dask/array/_info.py
@@ -130,7 +130,7 @@ class __array_namespace_info__:
 
         Returns
         -------
-        device : str
+        device : Device
             The default device used for new Dask arrays.
 
         Examples
@@ -335,7 +335,7 @@ class __array_namespace_info__:
 
         Returns
         -------
-        devices : list of str
+        devices : list[Device]
             The devices supported by Dask.
 
         See Also

--- a/array_api_compat/numpy/_aliases.py
+++ b/array_api_compat/numpy/_aliases.py
@@ -3,7 +3,7 @@ from __future__ import annotations
 from typing import Optional, Union
 
 from .._internal import get_xp
-from ..common import _aliases
+from ..common import _aliases, _helpers
 from ..common._typing import NestedSequence, SupportsBufferProtocol
 from ._info import __array_namespace_info__
 from ._typing import Array, Device, DType
@@ -92,8 +92,7 @@ def asarray(
     See the corresponding documentation in the array library and/or the array API
     specification for more details.
     """
-    if device not in ["cpu", None]:
-        raise ValueError(f"Unsupported device for NumPy: {device!r}")
+    _helpers._validate_device(np, device)
 
     if hasattr(np, '_CopyMode'):
         if copy is None:
@@ -119,6 +118,7 @@ def astype(
     copy: bool = True,
     device: Optional[Device] = None,
 ) -> Array:
+    _helpers._validate_device(np, device)
     return x.astype(dtype=dtype, copy=copy)
 
 

--- a/array_api_compat/numpy/_info.py
+++ b/array_api_compat/numpy/_info.py
@@ -119,7 +119,7 @@ class __array_namespace_info__:
 
         Returns
         -------
-        device : str
+        device : Device
             The default device used for new NumPy arrays.
 
         Examples
@@ -326,7 +326,7 @@ class __array_namespace_info__:
 
         Returns
         -------
-        devices : list of str
+        devices : list[Device]
             The devices supported by NumPy.
 
         See Also

--- a/array_api_compat/torch/_info.py
+++ b/array_api_compat/torch/_info.py
@@ -102,15 +102,24 @@ class __array_namespace_info__:
 
         Returns
         -------
-        device : str
+        device : Device
             The default device used for new PyTorch arrays.
 
         Examples
         --------
         >>> info = np.__array_namespace_info__()
         >>> info.default_device()
-        'cpu'
+        device(type='cpu')
 
+        Notes
+        -----
+        This method returns the static default device when yPyTorch is initialized.
+        However, the *current* device used by creation functions (``empty`` etc.)
+        can be changed at runtime.
+
+        See Also
+        --------
+        https://github.com/data-apis/array-api/issues/835
         """
         return torch.device("cpu")
 
@@ -120,9 +129,9 @@ class __array_namespace_info__:
 
         Parameters
         ----------
-        device : str, optional
-            The device to get the default data types for. For PyTorch, only
-            ``'cpu'`` is allowed.
+        device : Device, optional
+            The device to get the default data types for.
+            Unused for PyTorch, as all devices use the same default dtypes.
 
         Returns
         -------
@@ -250,8 +259,9 @@ class __array_namespace_info__:
 
         Parameters
         ----------
-        device : str, optional
+        device : Device, optional
             The device to get the data types for.
+            Unused for PyTorch, as all devices use the same dtypes.
         kind : str or tuple of str, optional
             The kind of data types to return. If ``None``, all data types are
             returned. If a string, only data types of that kind are returned.
@@ -310,7 +320,7 @@ class __array_namespace_info__:
 
         Returns
         -------
-        devices : list of str
+        devices : list[Device]
             The devices supported by PyTorch.
 
         See Also
@@ -333,6 +343,7 @@ class __array_namespace_info__:
         # device:
         try:
             torch.device('notadevice')
+            raise AssertionError("unreachable")  # pragma: nocover
         except RuntimeError as e:
             # The error message is something like:
             # "Expected one of cpu, cuda, ipu, xpu, mkldnn, opengl, opencl, ideep, hip, ve, fpga, ort, xla, lazy, vulkan, mps, meta, hpu, mtia, privateuseone device type at start of device string: notadevice"


### PR DESCRIPTION
- Add support for multiple devices in CuPy

  **UNTESTED:** I don't know how to test this without a dual-GPU box.
  Suggestions welcome. At any rate, any tests for this should be in `array-api-tests`,
  replicating the same pattern as in https://github.com/scipy/scipy/pull/22756.
- Validate `device` keyword in `array_api_compat.numpy.astype`
- Validate `device` keyword in all Dask functions
- Clarify `__array_namespace_info__().default_device()` output
  (pending discussion in https://github.com/data-apis/array-api/issues/835)
