### PR TITLE
MAINT: `__array_namespace_info__` docstrings tweaks

### DIFF
--- a/array_api_compat/common/_aliases.py
+++ b/array_api_compat/common/_aliases.py
@@ -18,7 +18,7 @@ from ._helpers import (
 
 # These functions are modified from the NumPy versions.
 
-# Creation functions add the device keyword (which does nothing for NumPy)
+# Creation functions add the device keyword (which does nothing for NumPy and Dask)
 
 def arange(
     start: Union[int, float],

--- a/array_api_compat/cupy/_info.py
+++ b/array_api_compat/cupy/_info.py
@@ -26,6 +26,7 @@ from cupy import (
     complex128,
 )
 
+
 class __array_namespace_info__:
     """
     Get the array API inspection namespace for CuPy.
@@ -117,7 +118,7 @@ class __array_namespace_info__:
 
         Returns
         -------
-        device : str
+        device : Device
             The default device used for new CuPy arrays.
 
         Examples
@@ -126,6 +127,15 @@ class __array_namespace_info__:
         >>> info.default_device()
         Device(0)
 
+        Notes
+        -----
+        This method returns the static default device when CuPy is initialized.
+        However, the *current* device used by creation functions (``empty`` etc.)
+        can be changed globally or with a context manager.
+
+        See Also
+        --------
+        https://github.com/data-apis/array-api/issues/835
         """
         return cuda.Device(0)
 
@@ -312,7 +322,7 @@ class __array_namespace_info__:
 
         Returns
         -------
-        devices : list of str
+        devices : list[Device]
             The devices supported by CuPy.
 
         See Also

--- a/array_api_compat/cupy/_info.py
+++ b/array_api_compat/cupy/_info.py
@@ -50,7 +50,7 @@ class __array_namespace_info__:
 
     Examples
     --------
-    >>> info = np.__array_namespace_info__()
+    >>> info = xp.__array_namespace_info__()
     >>> info.default_dtypes()
     {'real floating': cupy.float64,
      'complex floating': cupy.complex128,
@@ -95,7 +95,8 @@ class __array_namespace_info__:
         >>> info = xp.__array_namespace_info__()
         >>> info.capabilities()
         {'boolean indexing': True,
-         'data-dependent shapes': True}
+         'data-dependent shapes': True,
+         'max dimensions': 64}
 
         """
         return {

--- a/array_api_compat/cupy/_info.py
+++ b/array_api_compat/cupy/_info.py
@@ -101,7 +101,6 @@ class __array_namespace_info__:
         return {
             "boolean indexing": True,
             "data-dependent shapes": True,
-            # 'max rank' will be part of the 2024.12 standard
             "max dimensions": 64,
         }
 

--- a/array_api_compat/dask/array/_info.py
+++ b/array_api_compat/dask/array/_info.py
@@ -130,7 +130,7 @@ class __array_namespace_info__:
 
         Returns
         -------
-        device : str
+        device : Device
             The default device used for new Dask arrays.
 
         Examples
@@ -335,7 +335,7 @@ class __array_namespace_info__:
 
         Returns
         -------
-        devices : list of str
+        devices : list[Device]
             The devices supported by Dask.
 
         See Also

--- a/array_api_compat/dask/array/_info.py
+++ b/array_api_compat/dask/array/_info.py
@@ -50,7 +50,7 @@ class __array_namespace_info__:
 
     Examples
     --------
-    >>> info = np.__array_namespace_info__()
+    >>> info = xp.__array_namespace_info__()
     >>> info.default_dtypes()
     {'real floating': dask.float64,
      'complex floating': dask.complex128,
@@ -103,10 +103,11 @@ class __array_namespace_info__:
 
         Examples
         --------
-        >>> info = np.__array_namespace_info__()
+        >>> info = xp.__array_namespace_info__()
         >>> info.capabilities()
         {'boolean indexing': True,
-         'data-dependent shapes': True}
+         'data-dependent shapes': True,
+         'max dimensions': 64}
 
         """
         return {
@@ -135,7 +136,7 @@ class __array_namespace_info__:
 
         Examples
         --------
-        >>> info = np.__array_namespace_info__()
+        >>> info = xp.__array_namespace_info__()
         >>> info.default_device()
         'cpu'
 
@@ -173,7 +174,7 @@ class __array_namespace_info__:
 
         Examples
         --------
-        >>> info = np.__array_namespace_info__()
+        >>> info = xp.__array_namespace_info__()
         >>> info.default_dtypes()
         {'real floating': dask.float64,
          'complex floating': dask.complex128,
@@ -239,7 +240,7 @@ class __array_namespace_info__:
 
         Examples
         --------
-        >>> info = np.__array_namespace_info__()
+        >>> info = xp.__array_namespace_info__()
         >>> info.dtypes(kind='signed integer')
         {'int8': dask.int8,
          'int16': dask.int16,
@@ -347,7 +348,7 @@ class __array_namespace_info__:
 
         Examples
         --------
-        >>> info = np.__array_namespace_info__()
+        >>> info = xp.__array_namespace_info__()
         >>> info.devices()
         ['cpu', DASK_DEVICE]
 

--- a/array_api_compat/numpy/_info.py
+++ b/array_api_compat/numpy/_info.py
@@ -94,7 +94,8 @@ class __array_namespace_info__:
         >>> info = np.__array_namespace_info__()
         >>> info.capabilities()
         {'boolean indexing': True,
-         'data-dependent shapes': True}
+         'data-dependent shapes': True,
+         'max dimensions': 64}
 
         """
         return {

--- a/array_api_compat/numpy/_info.py
+++ b/array_api_compat/numpy/_info.py
@@ -119,7 +119,7 @@ class __array_namespace_info__:
 
         Returns
         -------
-        device : str
+        device : Device
             The default device used for new NumPy arrays.
 
         Examples
@@ -326,7 +326,7 @@ class __array_namespace_info__:
 
         Returns
         -------
-        devices : list of str
+        devices : list[Device]
             The devices supported by NumPy.
 
         See Also

--- a/array_api_compat/numpy/_info.py
+++ b/array_api_compat/numpy/_info.py
@@ -100,7 +100,6 @@ class __array_namespace_info__:
         return {
             "boolean indexing": True,
             "data-dependent shapes": True,
-            # 'max rank' will be part of the 2024.12 standard
             "max dimensions": 64,
         }
 

--- a/array_api_compat/torch/_info.py
+++ b/array_api_compat/torch/_info.py
@@ -102,15 +102,24 @@ class __array_namespace_info__:
 
         Returns
         -------
-        device : str
+        device : Device
             The default device used for new PyTorch arrays.
 
         Examples
         --------
         >>> info = np.__array_namespace_info__()
         >>> info.default_device()
-        'cpu'
+        device(type='cpu')
 
+        Notes
+        -----
+        This method returns the static default device when PyTorch is initialized.
+        However, the *current* device used by creation functions (``empty`` etc.)
+        can be changed at runtime.
+
+        See Also
+        --------
+        https://github.com/data-apis/array-api/issues/835
         """
         return torch.device("cpu")
 
@@ -120,9 +129,9 @@ class __array_namespace_info__:
 
         Parameters
         ----------
-        device : str, optional
-            The device to get the default data types for. For PyTorch, only
-            ``'cpu'`` is allowed.
+        device : Device, optional
+            The device to get the default data types for.
+            Unused for PyTorch, as all devices use the same default dtypes.
 
         Returns
         -------
@@ -250,8 +259,9 @@ class __array_namespace_info__:
 
         Parameters
         ----------
-        device : str, optional
+        device : Device, optional
             The device to get the data types for.
+            Unused for PyTorch, as all devices use the same dtypes.
         kind : str or tuple of str, optional
             The kind of data types to return. If ``None``, all data types are
             returned. If a string, only data types of that kind are returned.
@@ -310,7 +320,7 @@ class __array_namespace_info__:
 
         Returns
         -------
-        devices : list of str
+        devices : list[Device]
             The devices supported by PyTorch.
 
         See Also
@@ -333,6 +343,7 @@ class __array_namespace_info__:
         # device:
         try:
             torch.device('notadevice')
+            raise AssertionError("unreachable")  # pragma: nocover
         except RuntimeError as e:
             # The error message is something like:
             # "Expected one of cpu, cuda, ipu, xpu, mkldnn, opengl, opencl, ideep, hip, ve, fpga, ort, xla, lazy, vulkan, mps, meta, hpu, mtia, privateuseone device type at start of device string: notadevice"

--- a/array_api_compat/torch/_info.py
+++ b/array_api_compat/torch/_info.py
@@ -85,7 +85,6 @@ class __array_namespace_info__:
         return {
             "boolean indexing": True,
             "data-dependent shapes": True,
-            # 'max rank' will be part of the 2024.12 standard
             "max dimensions": 64,
         }
 

--- a/array_api_compat/torch/_info.py
+++ b/array_api_compat/torch/_info.py
@@ -34,7 +34,7 @@ class __array_namespace_info__:
 
     Examples
     --------
-    >>> info = np.__array_namespace_info__()
+    >>> info = xp.__array_namespace_info__()
     >>> info.default_dtypes()
     {'real floating': numpy.float64,
      'complex floating': numpy.complex128,
@@ -76,10 +76,11 @@ class __array_namespace_info__:
 
         Examples
         --------
-        >>> info = np.__array_namespace_info__()
+        >>> info = xp.__array_namespace_info__()
         >>> info.capabilities()
         {'boolean indexing': True,
-         'data-dependent shapes': True}
+         'data-dependent shapes': True,
+         'max dimensions': 64}
 
         """
         return {
@@ -106,7 +107,7 @@ class __array_namespace_info__:
 
         Examples
         --------
-        >>> info = np.__array_namespace_info__()
+        >>> info = xp.__array_namespace_info__()
         >>> info.default_device()
         device(type='cpu')
 
@@ -147,7 +148,7 @@ class __array_namespace_info__:
 
         Examples
         --------
-        >>> info = np.__array_namespace_info__()
+        >>> info = xp.__array_namespace_info__()
         >>> info.default_dtypes()
         {'real floating': torch.float32,
          'complex floating': torch.complex64,
@@ -296,7 +297,7 @@ class __array_namespace_info__:
 
         Examples
         --------
-        >>> info = np.__array_namespace_info__()
+        >>> info = xp.__array_namespace_info__()
         >>> info.dtypes(kind='signed integer')
         {'int8': numpy.int8,
          'int16': numpy.int16,
@@ -331,7 +332,7 @@ class __array_namespace_info__:
 
         Examples
         --------
-        >>> info = np.__array_namespace_info__()
+        >>> info = xp.__array_namespace_info__()
         >>> info.devices()
         [device(type='cpu'), device(type='mps', index=0), device(type='meta')]
 


### PR DESCRIPTION
- Clarify `__array_namespace_info__().default_device()` output.
Read controversy at https://github.com/data-apis/array-api/issues/835.
- Assorted minor tweaks to the docstrings of the `_info` modules
