### PR TITLE
BUG: Don't import helpers in namespaces

### DIFF
--- a/array_api_compat/common/_linalg.py
+++ b/array_api_compat/common/_linalg.py
@@ -174,3 +174,5 @@ __all__ = ['cross', 'matmul', 'outer', 'tensordot', 'EighResult',
            'svd', 'cholesky', 'matrix_rank', 'pinv', 'matrix_norm',
            'matrix_transpose', 'svdvals', 'vecdot', 'vector_norm', 'diagonal',
            'trace']
+
+_all_ignore = ['math', 'normalize_axis_tuple', 'get_xp', 'np', 'isdtype']

--- a/array_api_compat/cupy/__init__.py
+++ b/array_api_compat/cupy/__init__.py
@@ -8,9 +8,6 @@ from ._aliases import * # noqa: F403
 
 # See the comment in the numpy __init__.py
 __import__(__package__ + '.linalg')
-
 __import__(__package__ + '.fft')
-
-from ..common._helpers import * # noqa: F401,F403
 
 __array_api_version__ = '2024.12'

--- a/array_api_compat/dask/array/__init__.py
+++ b/array_api_compat/dask/array/__init__.py
@@ -5,5 +5,6 @@ from ._aliases import * # noqa: F403
 
 __array_api_version__ = '2024.12'
 
+# See the comment in the numpy __init__.py
 __import__(__package__ + '.linalg')
 __import__(__package__ + '.fft')

--- a/array_api_compat/numpy/__init__.py
+++ b/array_api_compat/numpy/__init__.py
@@ -14,17 +14,8 @@ from ._aliases import * # noqa: F403
 # It doesn't overwrite np.linalg from above. The import is generated
 # dynamically so that the library can be vendored.
 __import__(__package__ + '.linalg')
-
 __import__(__package__ + '.fft')
 
 from .linalg import matrix_transpose, vecdot # noqa: F401
-
-from ..common._helpers import * # noqa: F403
-
-try:
-    # Used in asarray(). Not present in older versions.
-    from numpy import _CopyMode # noqa: F401
-except ImportError:
-    pass
 
 __array_api_version__ = '2024.12'

--- a/array_api_compat/numpy/_aliases.py
+++ b/array_api_compat/numpy/_aliases.py
@@ -86,7 +86,7 @@ def asarray(
     *,
     dtype: Optional[DType] = None,
     device: Optional[Device] = None,
-    copy: "Optional[Union[bool, np._CopyMode]]" = None,
+    copy: Optional[Union[bool, np._CopyMode]] = None,
     **kwargs,
 ) -> Array:
     """

--- a/array_api_compat/torch/__init__.py
+++ b/array_api_compat/torch/__init__.py
@@ -9,16 +9,14 @@ for n in dir(torch):
         or 'cpu' in n
         or 'backward' in n):
         continue
-    exec(n + ' = torch.' + n)
+    exec(f"{n} = torch.{n}")
+del n
 
 # These imports may overwrite names from the import * above.
 from ._aliases import * # noqa: F403
 
 # See the comment in the numpy __init__.py
 __import__(__package__ + '.linalg')
-
 __import__(__package__ + '.fft')
-
-from ..common._helpers import * # noqa: F403
 
 __array_api_version__ = '2024.12'

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -276,7 +276,7 @@ def test_asarray_copy(library):
     is_lib_func = globals()[is_array_functions[library]]
     all = xp.all if library != 'dask.array' else lambda x: xp.all(x).compute()
 
-    if library == 'numpy' and xp.__version__[0] < '2' and not hasattr(xp, '_CopyMode') :
+    if library == 'numpy' and xp.__version__[0] < '2' and not hasattr(np, "_CopyMode"):
         supports_copy_false_other_ns = False
         supports_copy_false_same_ns = False
     elif library == 'cupy':


### PR DESCRIPTION
Remove helper functions from wrapped array namespaces.
This was introduced when the numpy namespace was split from the helpers in 2022 (b3a12d92e840be6ef0f87f568d68a4f58b55c7e7).
This PR prompted by a collision between `array_api_compat.device` and `torch.device`.

Re. deprecation layer: unsure if we need one? This was never advertised in the documentation.