### PR TITLE
TST: skip testing nextafter with scalars on torch

### DIFF
--- a/torch-xfails.txt
+++ b/torch-xfails.txt
@@ -144,6 +144,7 @@ array_api_tests/test_operators_and_elementwise_functions.py::test_binary_with_sc
 array_api_tests/test_operators_and_elementwise_functions.py::test_binary_with_scalars_real[logaddexp]
 array_api_tests/test_operators_and_elementwise_functions.py::test_binary_with_scalars_real[maximum]
 array_api_tests/test_operators_and_elementwise_functions.py::test_binary_with_scalars_real[minimum]
+array_api_tests/test_operators_and_elementwise_functions.py::test_binary_with_scalars_real[nextafter]
 
 # https://github.com/pytorch/pytorch/issues/149815
 array_api_tests/test_operators_and_elementwise_functions.py::test_binary_with_scalars_real[equal]


### PR DESCRIPTION
a companion to https://github.com/data-apis/array-api-tests/pull/366