### PR TITLE
TST: fix cupy `to_device` test on multiple devices

### DIFF
--- a/tests/test_cupy.py
+++ b/tests/test_cupy.py
@@ -8,15 +8,17 @@ from cupy.cuda import Stream
 def test_to_device_with_stream():
     devices = xp.__array_namespace_info__().devices()
     streams = [
-        Stream(),
-        Stream(non_blocking=True), 
-        Stream(null=True),
-        Stream(ptds=True), 
-        123,  # dlpack stream
+        lambda: Stream(),
+        lambda: Stream(non_blocking=True), 
+        lambda: Stream(null=True),
+        lambda: Stream(ptds=True), 
+        lambda: 123,  # dlpack stream
     ]
 
     a = xp.asarray([1, 2, 3])
     for dev in devices:
-        for stream in streams:
+        for stream_gen in streams:
+            with dev:
+                stream = stream_gen()
             b = to_device(a, dev, stream=stream)
             assert device(b) == dev

--- a/tests/test_cupy.py
+++ b/tests/test_cupy.py
@@ -12,7 +12,11 @@ from cupy.cuda import Stream
         lambda: Stream(non_blocking=True),
         lambda: Stream(null=True),
         lambda: Stream(ptds=True),
-        lambda: 123,  # dlpack stream
+        pytest.param(
+            lambda: 123,
+            id="dlpack stream",
+            marks=pytest.mark.skip(reason="segmentation fault reported (#326)")
+        ),
     ],
 )
 def test_to_device_with_stream(make_stream):


### PR DESCRIPTION
Fix `to_device` test for cupy when there are multiple devices.
UNTESTED, as I don't have multiple GPUs to try this on.
Partially fixes #324.