### PR TITLE
ENH: use torch.clamp for wrapped_torch.clip

### DIFF
--- a/tests/test_torch.py
+++ b/tests/test_torch.py
@@ -102,6 +102,18 @@ class TestResultType:
             torch.set_default_dtype(prev_default)
 
 
+def test_clip_vmap():
+    # https://github.com/data-apis/array-api-compat/issues/350
+    def apply_clip_compat(a):
+        return xp.clip(a, min=0, max=30)
+
+    a = xp.asarray([[5.1, 2.0, 64.1, -1.5]])
+
+    ref = apply_clip_compat(a)
+    v1 = torch.vmap(apply_clip_compat)
+    assert xp.all(v1(a) == ref)
+
+
 def test_meshgrid():
     """Verify that array_api_compat.torch.meshgrid defaults to indexing='xy'."""
 


### PR DESCRIPTION
Closes gh-350

Otherwise, the version which emulates "clip" fails with torch.vmap.

-------------

This patch is less innocuous than it looks, because it changes the promotion rules. Previously, `min` and `max` were not upcasting the result:

```
In [9]: xpn = array_namespace(np.arange(3))

In [10]: xpn.clip(xpn.arange(5, dtype=xpn.int8), 2, xpn.asarray(3.0))
Out[10]: array([2, 2, 2, 3, 3], dtype=int8)
```

and now they are:

```
In [11]: xpt = array_namespace(torch.ones(3))

In [12]: xpt.clip(xpt.arange(5, dtype=xpt.int8), 2, xpt.asarray(3.0))
Out[12]: tensor([2., 2., 2., 3., 3.])
```

OTOH, the wording in the spec, https://data-apis.org/array-api/draft/API_specification/generated/array_api.clip.html is 

> *min* ... *should* have the same data type as x.

and 

> If either `min` or `max` is an array having a different data type than `x`, behavior is unspecified and thus implementation-dependent.

