### PR TITLE
ENH: torch: allow negative indices in `take` and `take_along_axis`

### DIFF
--- a/array_api_compat/torch/_aliases.py
+++ b/array_api_compat/torch/_aliases.py
@@ -815,6 +815,8 @@ def take(x: Array, indices: Array, /, *, axis: int | None = None, **kwargs: obje
         if x.ndim != 1:
             raise ValueError("axis must be specified when ndim > 1")
         axis = 0
+    # torch does not support negative indices,
+    # see https://github.com/pytorch/pytorch/issues/146211
     return torch.index_select(
         x,
         axis,
@@ -824,6 +826,8 @@ def take(x: Array, indices: Array, /, *, axis: int | None = None, **kwargs: obje
 
 
 def take_along_axis(x: Array, indices: Array, /, *, axis: int = -1) -> Array:
+    # torch does not support negative indices,
+    # see https://github.com/pytorch/pytorch/issues/146211
     return torch.take_along_dim(
         x,
         torch.where(indices < 0, indices + x.shape[axis], indices),


### PR DESCRIPTION
fixes https://github.com/data-apis/array-api-compat/issues/360

A matching test update: https://github.com/data-apis/array-api-tests/pull/397