### PR TITLE
BUG: Fix `is_jax_array` for `jax>=0.8.2`

### DIFF
--- a/tests/test_jax.py
+++ b/tests/test_jax.py
@@ -46,9 +46,10 @@ def test_device_jit(func):
 
 
 def test_inside_jit():
-    jax = pytest.importorskip("jax")
-    import jax.numpy as jnp
-
+    # Test if jax arrays are handled correctly inside jax.jit.
+    # Jax tracers are not a subclass of jax.Array from 0.8.2 on. We explicitly test that
+    # tracers are handled appropriately. For limitations, see is_jax_array() docstring.
+    # Reference issue: https://github.com/data-apis/array-api-compat/issues/368
     x = jnp.asarray([1, 2, 3])
     assert jax.jit(is_jax_array)(x)
     assert jax.jit(is_array_api_obj)(x)


### PR DESCRIPTION
Jax released its version 0.8.2 https://github.com/jax-ml/jax/releases/tag/jax-v0.8.2, and it causes `is_jax_array` to no longer work for jit compiled arrays. This PR fixes the problem by also testing if the passed object is a `jax.core.Tracer` subclass.

### Considerations
The current design requires one more check, but the check is compatible with caching and thus should be fast. I'm somewhat worried about correctness though. Are there tracers that are not jax Arrays? Maybe @jakevdp can weigh in on that question.

### Related issue 
#368