### PR TITLE
REL: release 1.13.0

### DIFF
--- a/array_api_compat/__init__.py
+++ b/array_api_compat/__init__.py
@@ -17,6 +17,6 @@ to ensure they are not using functionality outside of the standard, but prefer
 this implementation for the default when working with NumPy arrays.
 
 """
-__version__ = '1.13.0.dev0'
+__version__ = '1.13.0'
 
 from .common import *  # noqa: F401, F403

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,34 @@
 # Changelog
 
+## 1.13.0 (2025-12-28)
+
+
+### Major changes
+
+- Support for Python 3.14 has been added.
+- Symbols exported in public namespaces have been reviewed and adjusted.
+- `torch.take` and `torch.take_along_axis` now support negative indices.
+- `torch.meshgrid` now correctly processes the `indexing` argument.
+- View/copy semantics are now observed for the `ceil`, `floor`, and `trunc` functions.
+
+### Minor changes
+
+- `array_namespace` has been sped up via caching.
+- The `stable` parameter of `torch.argsort` now defaults to `True`, per the standard.
+- Type annotations have seen progress.
+- `is_jax_array` has been adjusted for compatibility with `jax>=0.8.2`
+
+
+The following users contributed to this release:
+
+Evgeni Burovski,
+Guido Imperiale,
+Lucas Colley,
+Arthur Lacote,
+Martin Schuck,
+Matt Haberland.
+
+
 ## 1.12.0 (2025-05-13)
 
 


### PR DESCRIPTION
- [x] update version
- [x] green CI here
- [x] green CI on https://github.com/scipy/scipy/pull/24239
- [x] changelog
- [x] CuPy tests

```console
array-api-compat on 🎋 rel via 🐍
❯ pixi exec -s cupy -s hypothesis -s pytest-json-report -s ndindex ./test_cupy.sh
...
======================================== 1070 passed, 9 skipped, 96 xfailed, 61 xpassed, 182 warnings in 535.91s (0:08:55) ========================================
```