### PR TITLE
TST: test that clip(x) returns a copy not a view

### DIFF
--- a/tests/test_copies_or_views.py
+++ b/tests/test_copies_or_views.py
@@ -62,3 +62,15 @@ def test_view_or_copy(inputs, xp_name):
     is_view_wrapped = is_view(wrapped_func, a1, value)
 
     assert is_view_bare == is_view_wrapped
+
+
+@pytest.mark.parametrize('xp_name', wrapped_libraries + ['array_api_strict'])
+def test_clip_none(xp_name):
+    xp = import_(xp_name, wrapper=True)
+
+    if xp_name == 'array_api_strict' and xp.__version__ < "2.5":
+        # https://github.com/data-apis/array-api-strict/pull/180
+        pytest.xfail("clip(x) was only fixed in -strict == 2.5")
+
+    x = xp.arange(8)
+    assert not is_view(xp.clip, x, 42)


### PR DESCRIPTION
The spec only says that "If both min and max are None, the elements of the returned array must equal the respective elements in x"

Bare NumPy 2.x and CuPy 13.x return copes:

```
>>> x = np.arange(8); np.may_share_memory(x, np.clip(x))
False
```

Thus assume that all wrapped libraries should return a copy, too. Add a test to this effect.