### PR TITLE
TST: remove test_signature xfails

### DIFF
--- a/cupy-xfails.txt
+++ b/cupy-xfails.txt
@@ -203,11 +203,6 @@ array_api_tests/test_signatures.py::test_func_signature[from_dlpack]
 array_api_tests/test_signatures.py::test_array_method_signature[__dlpack__]
 
 # 2024.12 support
-array_api_tests/test_signatures.py::test_func_signature[bitwise_and]
-array_api_tests/test_signatures.py::test_func_signature[bitwise_left_shift]
-array_api_tests/test_signatures.py::test_func_signature[bitwise_or]
-array_api_tests/test_signatures.py::test_func_signature[bitwise_right_shift]
-array_api_tests/test_signatures.py::test_func_signature[bitwise_xor]
 array_api_tests/test_special_cases.py::test_binary[nextafter(x1_i is +0 and x2_i is -0) -> -0]
 
 # cupy 13.x follows numpy 1.x w/o weak promotion: result_type(int32, uint8, 1) != result_type(int32, uint8)

--- a/numpy-1-26-xfails.txt
+++ b/numpy-1-26-xfails.txt
@@ -43,11 +43,6 @@ array_api_tests/test_signatures.py::test_array_method_signature[__dlpack__]
 array_api_tests/test_manipulation_functions.py::test_repeat
 
 # 2024.12 support
-array_api_tests/test_signatures.py::test_func_signature[bitwise_and]
-array_api_tests/test_signatures.py::test_func_signature[bitwise_left_shift]
-array_api_tests/test_signatures.py::test_func_signature[bitwise_or]
-array_api_tests/test_signatures.py::test_func_signature[bitwise_right_shift]
-array_api_tests/test_signatures.py::test_func_signature[bitwise_xor]
 array_api_tests/test_data_type_functions.py::TestResultType::test_with_scalars
 
 array_api_tests/test_operators_and_elementwise_functions.py::test_where_with_scalars

--- a/numpy-dev-xfails.txt
+++ b/numpy-dev-xfails.txt
@@ -12,13 +12,6 @@ array_api_tests/test_signatures.py::test_extension_func_signature[linalg.vecdot]
 # uint64 repeats not supported
 array_api_tests/test_manipulation_functions.py::test_repeat
 
-# 2024.12 support
-array_api_tests/test_signatures.py::test_func_signature[bitwise_and]
-array_api_tests/test_signatures.py::test_func_signature[bitwise_left_shift]
-array_api_tests/test_signatures.py::test_func_signature[bitwise_or]
-array_api_tests/test_signatures.py::test_func_signature[bitwise_right_shift]
-array_api_tests/test_signatures.py::test_func_signature[bitwise_xor]
-
 # Stubs have a comment: (**note**: libraries may return ``NaN`` to match Python behavior.); Apparently, NumPy does just that
 array_api_tests/test_special_cases.py::test_binary[floor_divide(x1_i is +infinity and isfinite(x2_i) and x2_i > 0) -> +infinity]
 array_api_tests/test_special_cases.py::test_binary[floor_divide(x1_i is +infinity and isfinite(x2_i) and x2_i < 0) -> -infinity]

--- a/numpy-xfails.txt
+++ b/numpy-xfails.txt
@@ -12,13 +12,6 @@ array_api_tests/test_signatures.py::test_extension_func_signature[linalg.vecdot]
 # uint64 repeats not supported
 array_api_tests/test_manipulation_functions.py::test_repeat
 
-# 2024.12 support
-array_api_tests/test_signatures.py::test_func_signature[bitwise_and]
-array_api_tests/test_signatures.py::test_func_signature[bitwise_left_shift]
-array_api_tests/test_signatures.py::test_func_signature[bitwise_or]
-array_api_tests/test_signatures.py::test_func_signature[bitwise_right_shift]
-array_api_tests/test_signatures.py::test_func_signature[bitwise_xor]
-
 # Stubs have a comment: (**note**: libraries may return ``NaN`` to match Python behavior.); Apparently, NumPy does just that
 array_api_tests/test_special_cases.py::test_binary[floor_divide(x1_i is +infinity and isfinite(x2_i) and x2_i > 0) -> +infinity]
 array_api_tests/test_special_cases.py::test_binary[floor_divide(x1_i is +infinity and isfinite(x2_i) and x2_i < 0) -> -infinity]

--- a/torch-xfails.txt
+++ b/torch-xfails.txt
@@ -146,17 +146,6 @@ array_api_tests/test_signatures.py::test_func_signature[from_dlpack]
 # Argument 'max_version' missing from signature
 array_api_tests/test_signatures.py::test_array_method_signature[__dlpack__]
 
-# 2024.12 support
-array_api_tests/test_signatures.py::test_func_signature[bitwise_and]
-array_api_tests/test_signatures.py::test_func_signature[bitwise_left_shift]
-array_api_tests/test_signatures.py::test_func_signature[bitwise_or]
-array_api_tests/test_signatures.py::test_func_signature[bitwise_right_shift]
-array_api_tests/test_signatures.py::test_func_signature[bitwise_xor]
-array_api_tests/test_signatures.py::test_array_method_signature[__and__]
-array_api_tests/test_signatures.py::test_array_method_signature[__lshift__]
-array_api_tests/test_signatures.py::test_array_method_signature[__or__]
-array_api_tests/test_signatures.py::test_array_method_signature[__rshift__]
-array_api_tests/test_signatures.py::test_array_method_signature[__xor__]
 
 # 2024.12 support: binary functions reject python scalar arguments
 array_api_tests/test_operators_and_elementwise_functions.py::test_binary_with_scalars_real[atan2]


### PR DESCRIPTION
Were caused by failures in parsing, should be fixed by https://github.com/data-apis/array-api-tests/pull/418