### PR TITLE
TST: add skips for broadcast_shapes

### DIFF
--- a/dask-xfails.txt
+++ b/dask-xfails.txt
@@ -129,6 +129,11 @@ array_api_tests/test_linalg.py::test_matrix_norm
 array_api_tests/test_linalg.py::test_qr
 array_api_tests/test_manipulation_functions.py::test_roll
 
+# 2025.12 support
+array_api_tests/test_data_type_functions.py::TestBroadcastShapes::test_broadcast_shapes
+array_api_tests/test_data_type_functions.py::TestBroadcastShapes::test_empty
+array_api_tests/test_data_type_functions.py::TestBroadcastShapes::test_error
+
 # Stubs have a comment: (**note**: libraries may return ``NaN`` to match Python behavior.)
 array_api_tests/test_special_cases.py::test_binary[floor_divide(x1_i is +infinity and isfinite(x2_i) and x2_i > 0) -> +infinity]
 array_api_tests/test_special_cases.py::test_binary[floor_divide(x1_i is +infinity and isfinite(x2_i) and x2_i < 0) -> -infinity]

--- a/torch-xfails.txt
+++ b/torch-xfails.txt
@@ -166,3 +166,8 @@ array_api_tests/test_operators_and_elementwise_functions.py::test_binary_with_sc
 array_api_tests/test_operators_and_elementwise_functions.py::test_binary_with_scalars_bool[logical_and]
 array_api_tests/test_operators_and_elementwise_functions.py::test_binary_with_scalars_bool[logical_or]
 array_api_tests/test_operators_and_elementwise_functions.py::test_binary_with_scalars_bool[logical_xor]
+
+# 2025.12 support
+
+# torch raises a RuntimeError while the spec requires a ValueError
+array_api_tests/test_data_type_functions.py::TestBroadcastShapes::test_error


### PR DESCRIPTION
- dask does not implement `broadcast_shapes`
- torch emits a RuntimeError not ValueError