### PR TITLE
BUG: np.matrix is not an array API object

### DIFF
--- a/array_api_compat/common/_helpers.py
+++ b/array_api_compat/common/_helpers.py
@@ -288,8 +288,14 @@ def is_array_api_obj(x: object) -> TypeGuard[_ArrayApiObj]:
     is_dask_array
     is_jax_array
     """
+    try:
+        # TODO: drop this check after np.matrix is gone
+        if _issubclass_fast(type(x), "numpy", "matrix"):
+            return False
+    except Exception:
+        pass
     return (
-        hasattr(x, '__array_namespace__') 
+        hasattr(x, '__array_namespace__')
         or _is_array_api_cls(cast(Hashable, type(x)))
     )
 

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -1,0 +1,19 @@
+"""Test "unspecified" behavior which we cannot easily test in the Array API test suite.
+"""
+import warnings
+import pytest
+
+try:
+    import numpy as np
+except ImportError:
+    pytestmark = pytest.skip(allow_module_level=True, reason="numpy not found")
+
+from array_api_compat import is_array_api_obj
+
+def test_matrix_is_not_array_api_obj():
+    assert is_array_api_obj(np.asarray(3))
+    assert is_array_api_obj(np.float64(3))
+
+    with warnings.catch_warnings():
+        warnings.simplefilter("ignore", PendingDeprecationWarning)
+        assert not is_array_api_obj(np.matrix(3))


### PR DESCRIPTION
Being an ndarray subclass, np.matrix inherits the `__array_namespace__` method, even though it is not Array API compatible, and is not meant to be.

```
(Pdb) x
matrix([[3]])
(Pdb) p x.__array_namespace__() is np
True
```

closes gh-388