### PR TITLE
BLD: include `py.typed` in package

### DIFF
--- a/meson.build
+++ b/meson.build
@@ -11,6 +11,7 @@ sources_raw = {
   'array_api_compat': [
     'src/array_api_compat/__init__.py',
     'src/array_api_compat/_internal.py',
+    'src/array_api_compat/py.typed',
   ],
 
   'array_api_compat/common': [


### PR DESCRIPTION
this fixes a regression in moving to meson-python

closes gh-436 @jorenham 

<img width="689" height="582" alt="image" src="https://github.com/user-attachments/assets/8c3fc14f-daf0-4ffe-b5ed-247a81c4c134" />
