### PR TITLE
ENH: add top_k

### DIFF
--- a/src/array_api_compat/torch/_aliases.py
+++ b/src/array_api_compat/torch/_aliases.py
@@ -941,6 +941,26 @@ def meshgrid(*arrays: Array, indexing: Literal['xy', 'ij'] = 'xy') -> tuple[Arra
     return torch.meshgrid(*arrays, indexing=indexing) if arrays else ()
 
 
+def top_k(
+    a: Array,
+    k: int,
+    /,
+    *,
+    axis: int = -1,
+    mode: Literal["largest", "smallest"] = "largest",
+    **kwargs : object
+) -> tuple[Array, Array]:
+    if mode not in ["largest", "smallest"]:
+        raise ValueError(f"Invalid {mode = }.")
+    return torch.topk(
+        a,
+        k,
+        dim=axis,
+        largest = (mode == "largest"),
+        **kwargs
+    )
+
+
 __all__ = ['asarray', 'result_type', 'can_cast',
            'permute_dims', 'bitwise_invert', 'newaxis', 'conj', 'add',
            'atan2', 'bitwise_and', 'bitwise_left_shift', 'bitwise_or',
@@ -957,4 +977,5 @@ __all__ = ['asarray', 'result_type', 'can_cast',
            'UniqueAllResult', 'UniqueCountsResult', 'UniqueInverseResult',
            'unique_all', 'unique_counts', 'unique_inverse', 'unique_values',
            'matmul', 'matrix_transpose', 'vecdot', 'tensordot', 'isdtype',
-           'take', 'take_along_axis', 'sign', 'finfo', 'iinfo', 'repeat', 'meshgrid']
+           'take', 'take_along_axis', 'sign', 'finfo', 'iinfo', 'repeat', 'meshgrid',
+           'top_k']


### PR DESCRIPTION
Add basic `top_k` wrappers, per https://github.com/data-apis/array-api/pull/722/
-tests tracker: https://github.com/data-apis/array-api-tests/pull/438

- [x] `torch`
- [ ] `numpy` : works locally with https://github.com/numpy/numpy/pull/31659
- [ ] `cupy`
- [ ] `dask`

Supersedes and closes gh-158



To test locally: with this PR and https://github.com/data-apis/array-api-tests/pull/438, use
```
$ ARRAY_API_TESTS_SKIP_DTYPES=uint16,uint32,uint64 ARRAY_API_TESTS_VERSION=draft ARRAY_API_TESTS_MODULE=array_api_compat.torch pytest array_api_tests/test_searching_functions.py::test_top_k -s --max-examples=5000
```
