### PR TITLE
Improve clipping time with np_compat.clip

### DIFF
--- a/src/array_api_compat/numpy/_aliases.py
+++ b/src/array_api_compat/numpy/_aliases.py
@@ -152,12 +152,27 @@ def clip(
     else:
         result_shape = np.broadcast_shapes(x.shape, min_shape, max_shape)
 
-    # At least handle the case of Python integers correctly.
+    # Handle cases where the bounds are outside the range of the integer input dtype
+    # this covers integer arrays for float and integer bounds
+    # Also handle cases where the min/max are arrays/lists (replace values below min with iinfo.min and above max with iinfo.max)
     if np.issubdtype(dtype, np.integer):
-        if type(min) is int and min <= np.iinfo(dtype).min:
+        if np.issubdtype(type(min), np.integer) and min <= np.iinfo(dtype).min:
             min = None
-        if type(max) is int and max >= np.iinfo(dtype).max:
+        elif np.issubdtype(type(min), np.floating) and min < np.iinfo(dtype).min:
+            min = np.iinfo(dtype).min
+        elif isinstance(min, (list, tuple, Array)):
+            min[min < np.iinfo(dtype).min] = np.iinfo(dtype).min
+        if np.issubdtype(type(max), np.integer) and max >= np.iinfo(dtype).max:
             max = None
+        
+        elif np.issubdtype(type(max), np.floating) and max > np.iinfo(dtype).max:
+            max = np.iinfo(dtype).max
+
+        elif isinstance(max, (list, tuple, Array)):
+            max[max > np.iinfo(dtype).max] = np.iinfo(dtype).max
+    
+    # In the case of downcasting floats numpy replaces out of bounds with inf 
+    # This automatically handles those cases
 
     if min is None and max is None:
         if out is None:
@@ -208,7 +223,6 @@ def take_along_axis(x: Array, indices: Array, /, *, axis: int = -1) -> Array:
 
 
 # ceil, floor, and trunc return integers for integer inputs in NumPy < 2
-
 
 def ceil(x: Array, /) -> Array:
     if np.__version__ < '2' and np.issubdtype(x.dtype, np.integer):

--- a/src/array_api_compat/numpy/_aliases.py
+++ b/src/array_api_compat/numpy/_aliases.py
@@ -196,9 +196,7 @@ def count_nonzero(
 ) -> Array:
     # NOTE: this is currently incorrectly typed in numpy, but will be fixed in
     # numpy 2.2.5 and 2.3.0: https://github.com/numpy/numpy/pull/28750
-    result = cast(
-        "Any", np.count_nonzero(x, axis=axis, keepdims=keepdims)
-    )  # pyright: ignore[reportArgumentType, reportCallIssue]
+    result = cast("Any", np.count_nonzero(x, axis=axis, keepdims=keepdims))  # pyright: ignore[reportArgumentType, reportCallIssue]
     if axis is None and not keepdims:
         return np.asarray(result)
     return result
@@ -213,19 +211,19 @@ def take_along_axis(x: Array, indices: Array, /, *, axis: int = -1) -> Array:
 
 
 def ceil(x: Array, /) -> Array:
-    if np.__version__ < "2" and np.issubdtype(x.dtype, np.integer):
+    if np.__version__ < '2' and np.issubdtype(x.dtype, np.integer):
         return x.copy()
     return np.ceil(x)
 
 
 def floor(x: Array, /) -> Array:
-    if np.__version__ < "2" and np.issubdtype(x.dtype, np.integer):
+    if np.__version__ < '2' and np.issubdtype(x.dtype, np.integer):
         return x.copy()
     return np.floor(x)
 
 
 def trunc(x: Array, /) -> Array:
-    if np.__version__ < "2" and np.issubdtype(x.dtype, np.integer):
+    if np.__version__ < '2' and np.issubdtype(x.dtype, np.integer):
         return x.copy()
     return np.trunc(x)
 

--- a/src/array_api_compat/numpy/_aliases.py
+++ b/src/array_api_compat/numpy/_aliases.py
@@ -49,7 +49,6 @@ std = get_xp(np)(_aliases.std)
 var = get_xp(np)(_aliases.var)
 cumulative_sum = get_xp(np)(_aliases.cumulative_sum)
 cumulative_prod = get_xp(np)(_aliases.cumulative_prod)
-clip = get_xp(np)(_aliases.clip)
 permute_dims = get_xp(np)(_aliases.permute_dims)
 reshape = get_xp(np)(_aliases.reshape)
 argsort = get_xp(np)(_aliases.argsort)
@@ -106,6 +105,80 @@ def astype(
     return x.astype(dtype=dtype, copy=copy)
 
 
+def clip(
+    x: Array,
+    /,
+    min: float | Array | None = None,
+    max: float | Array | None = None,
+    *,
+    out: Array | None = None,
+) -> Array:
+    """Array API compatible clip implementation for NumPy.
+
+    NumPy's native ``clip`` is used directly after casting bounds to the
+    input dtype. This keeps the result dtype aligned with ``x.dtype`` and
+    avoids NumPy's default promotion behavior.
+
+    Args:
+        x: Input array.
+        min: Minimum bound. If None, no lower bound is applied.
+        max: Maximum bound. If None, no upper bound is applied.
+        out: Optional output array to store the result, has to have dtype of x
+    """
+
+    def _bound_shape(a: object) -> tuple[int, ...]:
+        if a is None or np.isscalar(a):
+            return ()
+        return np.asarray(a).shape
+
+    dtype = x.dtype
+    out_dtype = out.dtype if out is not None else dtype
+    if out_dtype != dtype:
+        raise ValueError(f"Output array has dtype {out_dtype}, but input array has dtype {dtype}")
+    min_shape = _bound_shape(min)
+    max_shape = _bound_shape(max)
+
+    # avoid shape broadcasting and copying when not necessary
+    if min_shape == () and max_shape == ():
+        result_shape = x.shape
+    else:
+        result_shape = np.broadcast_shapes(x.shape, min_shape, max_shape)
+
+    # At least handle the case of Python integers correctly.
+    if np.issubdtype(dtype, np.integer):
+        if type(min) is int and min <= np.iinfo(dtype).min:
+            min = None
+        if type(max) is int and max >= np.iinfo(dtype).max:
+            max = None
+
+    if min is None and max is None:
+        if out is None:
+            return x.copy()[()]
+        np.copyto(out, x)
+        return out[()]
+
+    # Cast clip parameters to the input dtype and broadcast them to the result shape.
+    a_min = None
+    if min is not None:
+        a_min = np.asarray(min, dtype=dtype)
+        if a_min.shape != result_shape:
+            # Casting first keeps NumPy from promoting the output dtype.
+            a_min = np.broadcast_to(a_min, result_shape)
+
+    a_max = None
+    if max is not None:
+        a_max = np.asarray(max, dtype=dtype)
+        if a_max.shape != result_shape:
+            # Casting first keeps NumPy from promoting the output dtype.
+            a_max = np.broadcast_to(a_max, result_shape)
+
+    if out is None:
+        out = np.empty(result_shape, dtype=dtype)
+
+    np.clip(x, a_min, a_max, out=out, casting="no")
+    return out[()]
+
+
 # count_nonzero returns a python int for axis=None and keepdims=False
 # https://github.com/numpy/numpy/issues/17562
 def count_nonzero(
@@ -115,7 +188,9 @@ def count_nonzero(
 ) -> Array:
     # NOTE: this is currently incorrectly typed in numpy, but will be fixed in
     # numpy 2.2.5 and 2.3.0: https://github.com/numpy/numpy/pull/28750
-    result = cast("Any", np.count_nonzero(x, axis=axis, keepdims=keepdims))  # pyright: ignore[reportArgumentType, reportCallIssue]
+    result = cast(
+        "Any", np.count_nonzero(x, axis=axis, keepdims=keepdims)
+    )  # pyright: ignore[reportArgumentType, reportCallIssue]
     if axis is None and not keepdims:
         return np.asarray(result)
     return result
@@ -128,20 +203,21 @@ def take_along_axis(x: Array, indices: Array, /, *, axis: int = -1) -> Array:
 
 # ceil, floor, and trunc return integers for integer inputs in NumPy < 2
 
+
 def ceil(x: Array, /) -> Array:
-    if np.__version__ < '2' and np.issubdtype(x.dtype, np.integer):
+    if np.__version__ < "2" and np.issubdtype(x.dtype, np.integer):
         return x.copy()
     return np.ceil(x)
 
 
 def floor(x: Array, /) -> Array:
-    if np.__version__ < '2' and np.issubdtype(x.dtype, np.integer):
+    if np.__version__ < "2" and np.issubdtype(x.dtype, np.integer):
         return x.copy()
     return np.floor(x)
 
 
 def trunc(x: Array, /) -> Array:
-    if np.__version__ < '2' and np.issubdtype(x.dtype, np.integer):
+    if np.__version__ < "2" and np.issubdtype(x.dtype, np.integer):
         return x.copy()
     return np.trunc(x)
 
@@ -173,6 +249,7 @@ __all__ = _aliases.__all__ + [
     "atan",
     "atan2",
     "atanh",
+    "clip",
     "ceil",
     "floor",
     "trunc",
@@ -183,7 +260,7 @@ __all__ = _aliases.__all__ + [
     "concat",
     "count_nonzero",
     "pow",
-    "take_along_axis"
+    "take_along_axis",
 ]
 
 

--- a/src/array_api_compat/numpy/_aliases.py
+++ b/src/array_api_compat/numpy/_aliases.py
@@ -162,14 +162,21 @@ def clip(
             min = None
         elif np.issubdtype(type(min), np.floating) and min < np.iinfo(dtype).min:
             min = np.iinfo(dtype).min
-        elif isinstance(min, (list, tuple, Array)):
+        elif isinstance(min, (list, Array)):
             min[min < np.iinfo(dtype).min] = np.iinfo(dtype).min
+        elif isinstance(min, tuple):
+            min = np.asarray(min)
+            min[min < np.iinfo(dtype).min] = np.iinfo(dtype).min
+            
         
         if np.issubdtype(type(max), np.integer) and max >= np.iinfo(dtype).max:
             max = None
         elif np.issubdtype(type(max), np.floating) and max > np.iinfo(dtype).max:
             max = np.iinfo(dtype).max
-        elif isinstance(max, (list, tuple, Array)):
+        elif isinstance(max, (list, Array)):
+            max[max > np.iinfo(dtype).max] = np.iinfo(dtype).max
+        elif isinstance(max, tuple):
+            max = np.asarray(max)
             max[max > np.iinfo(dtype).max] = np.iinfo(dtype).max
     
     # In the case of downcasting floats numpy replaces out of bounds with inf 

--- a/src/array_api_compat/numpy/_aliases.py
+++ b/src/array_api_compat/numpy/_aliases.py
@@ -110,7 +110,6 @@ def clip(
     /,
     min: float | Array | None = None,
     max: float | Array | None = None,
-    out: Array | None = None,
     **kwargs,
 ) -> Array:
     """Array API compatible clip implementation for NumPy.
@@ -125,6 +124,13 @@ def clip(
         max: Maximum bound. If None, no upper bound is applied.
         out: Optional output array to store the result, has to have dtype of x
     """
+    # out is a possible *kwarg for numpy.clip, but not in the array API spec. We handle it here to
+    # avoid having to add it to the array API spec, which would be a breaking change
+    # check if out in kwargs, if so pop it and use it as the out parameter
+    if "out" in kwargs:
+        out = kwargs.pop("out")
+    else:
+        out = None
 
     def _bound_shape(a: object) -> tuple[int, ...]:
         if a is None or np.isscalar(a):
@@ -134,7 +140,9 @@ def clip(
     dtype = x.dtype
     out_dtype = out.dtype if out is not None else dtype
     if out_dtype != dtype:
-        raise ValueError(f"Output array has dtype {out_dtype}, but input array has dtype {dtype}")
+        raise ValueError(
+            f"Output array has dtype {out_dtype}, but input array has dtype {dtype}"
+            )
     min_shape = _bound_shape(min)
     max_shape = _bound_shape(max)
 

--- a/src/array_api_compat/numpy/_aliases.py
+++ b/src/array_api_compat/numpy/_aliases.py
@@ -122,6 +122,7 @@ def clip(
         x: Input array.
         min: Minimum bound. If None, no lower bound is applied.
         max: Maximum bound. If None, no upper bound is applied.
+        **kwargs: Additional keyword arguments passed to ``np.clip``.
         out: Optional output array to store the result, has to have dtype of x
     """
     # out is a possible *kwarg for numpy.clip, but not in the array API spec. We handle it here to
@@ -156,24 +157,25 @@ def clip(
     # this covers integer arrays for float and integer bounds
     # Also handle cases where the min/max are arrays/lists (replace values below min with iinfo.min and above max with iinfo.max)
     if np.issubdtype(dtype, np.integer):
+        
         if np.issubdtype(type(min), np.integer) and min <= np.iinfo(dtype).min:
             min = None
         elif np.issubdtype(type(min), np.floating) and min < np.iinfo(dtype).min:
             min = np.iinfo(dtype).min
         elif isinstance(min, (list, tuple, Array)):
             min[min < np.iinfo(dtype).min] = np.iinfo(dtype).min
+        
         if np.issubdtype(type(max), np.integer) and max >= np.iinfo(dtype).max:
             max = None
-        
         elif np.issubdtype(type(max), np.floating) and max > np.iinfo(dtype).max:
             max = np.iinfo(dtype).max
-
         elif isinstance(max, (list, tuple, Array)):
             max[max > np.iinfo(dtype).max] = np.iinfo(dtype).max
     
     # In the case of downcasting floats numpy replaces out of bounds with inf 
     # This automatically handles those cases
-
+    
+    # Early return for simple cases
     if min is None and max is None:
         if out is None:
             return x.copy()[()]

--- a/src/array_api_compat/numpy/_aliases.py
+++ b/src/array_api_compat/numpy/_aliases.py
@@ -162,9 +162,9 @@ def clip(
             min = None
         elif np.issubdtype(type(min), np.floating) and min < np.iinfo(dtype).min:
             min = np.iinfo(dtype).min
-        elif isinstance(min, (list, Array)):
+        elif isinstance(min, Array):
             min[min < np.iinfo(dtype).min] = np.iinfo(dtype).min
-        elif isinstance(min, tuple):
+        elif isinstance(min, (list,tuple)):
             min = np.asarray(min)
             min[min < np.iinfo(dtype).min] = np.iinfo(dtype).min
             
@@ -173,9 +173,9 @@ def clip(
             max = None
         elif np.issubdtype(type(max), np.floating) and max > np.iinfo(dtype).max:
             max = np.iinfo(dtype).max
-        elif isinstance(max, (list, Array)):
+        elif isinstance(max, Array):
             max[max > np.iinfo(dtype).max] = np.iinfo(dtype).max
-        elif isinstance(max, tuple):
+        elif isinstance(max, (list,tuple)):
             max = np.asarray(max)
             max[max > np.iinfo(dtype).max] = np.iinfo(dtype).max
     

--- a/src/array_api_compat/numpy/_aliases.py
+++ b/src/array_api_compat/numpy/_aliases.py
@@ -110,8 +110,8 @@ def clip(
     /,
     min: float | Array | None = None,
     max: float | Array | None = None,
-    *,
     out: Array | None = None,
+    **kwargs,
 ) -> Array:
     """Array API compatible clip implementation for NumPy.
 
@@ -175,7 +175,7 @@ def clip(
     if out is None:
         out = np.empty(result_shape, dtype=dtype)
 
-    np.clip(x, a_min, a_max, out=out, casting="no")
+    np.clip(x, a_min, a_max, out=out, casting="no", **kwargs)
     return out[()]
 
 

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -1,5 +1,5 @@
-"""Test "unspecified" behavior which we cannot easily test in the Array API test suite.
-"""
+"""Test "unspecified" behavior which we cannot easily test in the Array API test suite."""
+
 import warnings
 import pytest
 
@@ -9,6 +9,34 @@ except ImportError:
     pytestmark = pytest.skip(allow_module_level=True, reason="numpy not found")
 
 from array_api_compat import is_array_api_obj
+
+
+def test_numpy_clip_out_and_broadcast():
+    from array_api_compat import numpy as xp
+
+    x = xp.asarray([[10, 20, 30], [40, 50, 60]], dtype=np.uint8)
+    min_bound = xp.asarray([15, 35, 55], dtype=np.int16)
+    max_bound = xp.asarray([25, 45, 65], dtype=np.int16)
+    out = xp.empty_like(x)
+
+    result = xp.clip(x, min_bound, max_bound, out=out)
+
+    assert result is out
+    assert out.dtype == x.dtype
+    np.testing.assert_array_equal(out, xp.asarray([[15, 20, 30], [25, 45, 60]], dtype=np.uint8))
+
+
+def test_numpy_clip_returns_copy_when_unbounded():
+    from array_api_compat import numpy as xp
+
+    x = xp.arange(8, dtype=np.int64)
+
+    y = xp.clip(x)
+
+    assert y.dtype == x.dtype
+    assert not np.shares_memory(x, y)
+    np.testing.assert_array_equal(y, x)
+
 
 def test_matrix_is_not_array_api_obj():
     assert is_array_api_obj(np.asarray(3))

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -9,10 +9,10 @@ except ImportError:
     pytestmark = pytest.skip(allow_module_level=True, reason="numpy not found")
 
 from array_api_compat import is_array_api_obj
-
+from array_api_compat import numpy as xp
 
 def test_numpy_clip_out_and_broadcast():
-    from array_api_compat import numpy as xp
+    
 
     x = xp.asarray([[10, 20, 30], [40, 50, 60]], dtype=np.uint8)
     min_bound = xp.asarray([15, 35, 55], dtype=np.int16)
@@ -27,7 +27,6 @@ def test_numpy_clip_out_and_broadcast():
 
 
 def test_numpy_clip_uint8_casts_bounds_outside_range():
-    from array_api_compat import numpy as xp
 
     x = xp.asarray([0, 10, 250], dtype=np.uint8)
     min_bound = np.int16(-1)
@@ -40,7 +39,6 @@ def test_numpy_clip_uint8_casts_bounds_outside_range():
 
 
 def test_numpy_clip_int64_casts_bounds_outside_range():
-    from array_api_compat import numpy as xp
 
     x = xp.asarray([-(2**63), -1, 0, 2**63 - 1], dtype=np.int64)
     min_bound = np.float64(-1e20)

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -23,7 +23,7 @@ def test_numpy_clip_out_and_broadcast():
 
     assert result is out
     assert out.dtype == x.dtype
-    np.testing.assert_array_equal(out, xp.asarray([[15, 20, 30], [25, 45, 60]], dtype=np.uint8))
+    np.testing.assert_array_equal(out, xp.asarray([[15, 35, 55], [25, 45, 60]], dtype=np.uint8))
 
 
 def test_numpy_clip_uint8_casts_bounds_outside_range():

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -92,14 +92,14 @@ def test_numpy_type_promotion():
     max_bound = np.float64(1.0001)
     result = xp.clip(x, min_bound, max_bound)
     assert result.dtype == x.dtype
-    assert result == xp.asarray([-1, -1, 0, 1], dtype=np.int64)
+    np.testing.assert_array_equal(result, xp.asarray([-1, -1, 0, 1], dtype=np.int64))
     
     # ensure clipping with int16 bounds
     min_bound = np.int16(-1)
     max_bound = np.int16(1)
     result = xp.clip(x, min_bound, max_bound)
     assert result.dtype == x.dtype
-    assert result == xp.asarray([-1, -1, 0, 1], dtype=np.int64)
+    np.testing.assert_array_equal(result, xp.asarray([-1, -1, 0, 1], dtype=np.int64))
     
     # final test with uint8 image and int64 bounds
     x = xp.asarray([0, 10, 250], dtype=np.uint8)
@@ -107,8 +107,8 @@ def test_numpy_type_promotion():
     max_bound = np.int64(32)
     result = xp.clip(x, min_bound, max_bound)
     assert result.dtype == x.dtype
-    assert result == xp.asarray([0, 10, 32], dtype=np.uint8)
-
+    np.testing.assert_array_equal(result, xp.asarray([0, 10, 32], dtype=np.uint8))
+    
 def test_numpy_clip_float16_casts_bounds_outside_range():
     """Test that float16 bounds outside the range of input dtype still work for float16 arrays"""
     x = xp.asarray([0.0, 1.5, 3.0], dtype=np.float16)

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -12,7 +12,6 @@ from array_api_compat import is_array_api_obj
 from array_api_compat import numpy as xp
 
 def test_numpy_clip_out_and_broadcast():
-    
 
     x = xp.asarray([[10, 20, 30], [40, 50, 60]], dtype=np.uint8)
     min_bound = xp.asarray([15, 35, 55], dtype=np.int16)
@@ -26,8 +25,8 @@ def test_numpy_clip_out_and_broadcast():
     np.testing.assert_array_equal(out, xp.asarray([[15, 35, 55], [25, 45, 60]], dtype=np.uint8))
 
 
-def test_numpy_clip_uint8_casts_bounds_outside_range():
-
+def test_numpy_clip_all_bounds_work_with_int_arrays():
+    """Test that integer bounds outside the range of input dtype still work for integer arrays"""
     x = xp.asarray([0, 10, 250], dtype=np.uint8)
     min_bound = np.int16(-1)
     max_bound = np.int16(200)
@@ -35,11 +34,12 @@ def test_numpy_clip_uint8_casts_bounds_outside_range():
     result = xp.clip(x, min_bound, max_bound)
 
     assert result.dtype == x.dtype
-    np.testing.assert_array_equal(result, xp.asarray([200, 200, 200], dtype=np.uint8))
+    np.testing.assert_array_equal(result, xp.asarray([0, 10, 200], dtype=np.uint8))
 
-
-def test_numpy_clip_int64_casts_bounds_outside_range():
-
+    """
+    min and max bounds are below what can be represented by int64, 
+    so they should be clipped to the min/max of int64
+    """
     x = xp.asarray([-(2**63), -1, 0, 2**63 - 1], dtype=np.int64)
     min_bound = np.float64(-1e20)
     max_bound = np.float64(1e20)
@@ -51,21 +51,69 @@ def test_numpy_clip_int64_casts_bounds_outside_range():
         result,
         xp.asarray(
             [
-                np.iinfo(np.int64).min,
-                np.iinfo(np.int64).min,
-                np.iinfo(np.int64).min,
-                np.iinfo(np.int64).min,
+            -(2**63), -1, 0, 2**63 - 1
             ],
             dtype=np.int64,
         ),
     )
 
 
-def test_numpy_clip_float16_casts_bounds_outside_range():
-    from array_api_compat import numpy as xp
+def test_array_min_max_broadcasting_when_clipped():
+    """ Tests a min as tuple list array of floats input for an integer array
+    Should be clipped by min/max of the integer array"""
+    x=xp.asarray([0, 10, 100], dtype=np.uint8)
+    min_bound = xp.asarray([np.float64(-1e20), 5.0, 200.0], dtype=np.float32)
+    max_bound = None
+    result=xp.clip(x, min_bound, max_bound)
+    assert result.dtype == x.dtype
+    np.testing.assert_array_equal(result, xp.asarray([0, 10, 200], dtype=np.uint8))
 
+    # now test with a tuple
+    min_bound = (np.float64(-1e20), 5.0, 200.0)
+    result=xp.clip(x, min_bound, max_bound)
+    assert result.dtype == x.dtype
+    np.testing.assert_array_equal(result, xp.asarray([0, 10, 200], dtype=np.uint8))
+    
+    # test with a list
+    min_bound = [np.float64(-1e20), 5.0, 200.0]
+    result=xp.clip(x, min_bound, max_bound)
+    assert result.dtype == x.dtype
+    np.testing.assert_array_equal(result, xp.asarray([0, 10, 200], dtype=np.uint8))
+
+def test_numpy_type_promotion():
+    """ Added to adress comment from main alias file:
+    # np.clip does type promotion but the array API clip requires that the
+    # output have the same dtype as x. We do this instead of just downcasting
+    # the result of xp.clip() to handle some corner cases better (e.g.,
+    # avoiding uint64 -> float64 promotion).
+    """
+    # ensure clipping with float bounds
+    x = xp.asarray([-(2**63), -1, 0, 2**63 - 1], dtype=np.int64)
+    min_bound = np.float64(-1.0001)
+    max_bound = np.float64(1.0001)
+    result = xp.clip(x, min_bound, max_bound)
+    assert result.dtype == x.dtype
+    assert result == xp.asarray([-1, -1, 0, 1], dtype=np.int64)
+    
+    # ensure clipping with int16 bounds
+    min_bound = np.int16(-1)
+    max_bound = np.int16(1)
+    result = xp.clip(x, min_bound, max_bound)
+    assert result.dtype == x.dtype
+    assert result == xp.asarray([-1, -1, 0, 1], dtype=np.int64)
+    
+    # final test with uint8 image and int64 bounds
+    x = xp.asarray([0, 10, 250], dtype=np.uint8)
+    min_bound = np.int64(-1)
+    max_bound = np.int64(32)
+    result = xp.clip(x, min_bound, max_bound)
+    assert result.dtype == x.dtype
+    assert result == xp.asarray([0, 10, 32], dtype=np.uint8)
+
+def test_numpy_clip_float16_casts_bounds_outside_range():
+    """Test that float16 bounds outside the range of input dtype still work for float16 arrays"""
     x = xp.asarray([0.0, 1.5, 3.0], dtype=np.float16)
-    min_bound = np.float32(-1e10)
+    min_bound = np.float32(-1e10) # outside of float16 range
     max_bound = np.float32(2.0)
 
     result = xp.clip(x, min_bound, max_bound)
@@ -75,7 +123,6 @@ def test_numpy_clip_float16_casts_bounds_outside_range():
 
 
 def test_numpy_clip_returns_copy_when_unbounded():
-    from array_api_compat import numpy as xp
 
     x = xp.arange(8, dtype=np.int64)
 

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -36,10 +36,9 @@ def test_numpy_clip_all_bounds_work_with_int_arrays():
     assert result.dtype == x.dtype
     np.testing.assert_array_equal(result, xp.asarray([0, 10, 200], dtype=np.uint8))
 
-    """
-    min and max bounds are below what can be represented by int64, 
-    so they should be clipped to the min/max of int64
-    """
+
+    # min and max bounds are below what can be represented by int64, 
+    # so they should be clipped to the min/max of int64
     x = xp.asarray([-(2**63), -1, 0, 2**63 - 1], dtype=np.int64)
     min_bound = np.float64(-1e20)
     max_bound = np.float64(1e20)
@@ -81,7 +80,7 @@ def test_array_min_max_broadcasting_when_clipped():
     np.testing.assert_array_equal(result, xp.asarray([0, 10, 200], dtype=np.uint8))
 
 def test_numpy_type_promotion():
-    """ Added to adress comment from main alias file:
+    """ Added to address comment from main alias file:
     # np.clip does type promotion but the array API clip requires that the
     # output have the same dtype as x. We do this instead of just downcasting
     # the result of xp.clip() to handle some corner cases better (e.g.,

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -26,6 +26,56 @@ def test_numpy_clip_out_and_broadcast():
     np.testing.assert_array_equal(out, xp.asarray([[15, 20, 30], [25, 45, 60]], dtype=np.uint8))
 
 
+def test_numpy_clip_uint8_casts_bounds_outside_range():
+    from array_api_compat import numpy as xp
+
+    x = xp.asarray([0, 10, 250], dtype=np.uint8)
+    min_bound = np.int16(-1)
+    max_bound = np.int16(200)
+
+    result = xp.clip(x, min_bound, max_bound)
+
+    assert result.dtype == x.dtype
+    np.testing.assert_array_equal(result, xp.asarray([200, 200, 200], dtype=np.uint8))
+
+
+def test_numpy_clip_int64_casts_bounds_outside_range():
+    from array_api_compat import numpy as xp
+
+    x = xp.asarray([-(2**63), -1, 0, 2**63 - 1], dtype=np.int64)
+    min_bound = np.float64(-1e20)
+    max_bound = np.float64(1e20)
+
+    result = xp.clip(x, min_bound, max_bound)
+
+    assert result.dtype == x.dtype
+    np.testing.assert_array_equal(
+        result,
+        xp.asarray(
+            [
+                np.iinfo(np.int64).min,
+                np.iinfo(np.int64).min,
+                np.iinfo(np.int64).min,
+                np.iinfo(np.int64).min,
+            ],
+            dtype=np.int64,
+        ),
+    )
+
+
+def test_numpy_clip_float16_casts_bounds_outside_range():
+    from array_api_compat import numpy as xp
+
+    x = xp.asarray([0.0, 1.5, 3.0], dtype=np.float16)
+    min_bound = np.float32(-1e10)
+    max_bound = np.float32(2.0)
+
+    result = xp.clip(x, min_bound, max_bound)
+
+    assert result.dtype == x.dtype
+    np.testing.assert_array_equal(result, xp.asarray([0.0, 1.5, 2.0], dtype=np.float16))
+
+
 def test_numpy_clip_returns_copy_when_unbounded():
     from array_api_compat import numpy as xp
 

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -21,8 +21,8 @@ def test_numpy_clip_out_and_broadcast():
 
     result = xp.clip(x, min_bound, max_bound, out=out)
 
-    assert result is out
-    assert out.dtype == x.dtype
+    np.testing.assert_array_equal(result, xp.asarray([[15, 35, 55], [25, 45, 60]], dtype=np.uint8))
+    assert result.dtype == x.dtype
     np.testing.assert_array_equal(out, xp.asarray([[15, 35, 55], [25, 45, 60]], dtype=np.uint8))
 
 


### PR DESCRIPTION
This PR introduces a numpy specific alias to xp.clip to improve performance, adressing Issue #444.
With respect to the basic implementation I removed array copies and new creations where possible and revert to the intrinsic np.clip.

The benchmark also implies that dask clip is quite below its possible performance, as it remains well below the other programs.

As far as I can tell this rewrite is compliant with the API standard, but please advise if not.
I am happy to receive feedback. 

## Current on main (run on a laptop, no GPU):
Batch size: 1024
Image shape: (128, 128, 3)
Measurement runs: 8

Skipped backends: cupy (unavailable)

| backend | dtype | avg ms | std ms | images/s | std images/s |
| --- | --- | ---: | ---: | ---: | ---: |
| numpy-native  | float32 | 230.097 | 20.311 | 4450.3 | 357.8 |
| numpy-native  | uint8 | 60.985 | 8.060 | 16790.9 | 1877.6 |
| numpy         | float32 | 4765.966 | 298.603 | 214.9 | 13.6 |
| numpy         | uint8 | 3194.393 | 266.443 | 320.6 | 27.0 |
| dask          | float32 | 3279.046 | 513.540 | 312.3 | 49.4 |
| dask          | uint8 | 1657.283 | 168.447 | 617.9 | 67.7 |
| jax           | float32 | 197.261 | 71.699 | 5191.1 | 1549.5 |
| jax           | uint8 | 38.581 | 7.265 | 26541.4 | 4950.1 |
| pytorch       | float32 | 160.713 | 54.031 | 6371.6 | 1940.3 |
| pytorch       | uint8 | 16.838 | 3.103 | 60814.3 | 13022.6 |

## Now on this branch

Batch size: 1024
Image shape: (128, 128, 3)
Measurement runs: 15

| backend | dtype | avg ms | std ms | images/s | std images/s |
| --- | --- | ---: | ---: | ---: | ---: |
| numpy-native | float32 | 156.005 | 27.627 | 6563.9 | 1260.4 |
| numpy-native | uint8 | 34.172 | 5.294 | 29965.8 | 4482.5 |
| numpy | float32 | 157.614 | 30.625 | 6496.9 | 1226.8 |
| numpy | uint8 | 41.640 | 7.193 | 24592.0 | 4832.1 |
| dask | float32 | 1675.356 | 204.533 | 611.2 | 81.3 |
| dask | uint8 | 1544.973 | 493.518 | 662.8 | 169.1 |
| jax | float32 | 81.755 | 30.772 | 12525.2 | 3866.9 |
| jax | uint8 | 42.276 | 66.549 | 24221.9 | 13959.8 |
| pytorch | float32 | 86.618 | 34.658 | 11822.1 | 3924.1 |
| pytorch | uint8 | 16.298 | 3.716 | 62829.0 | 12721.9 |





As evident the new clip version for numpy restores its native performance, while ensuring the same broadcasting and dtype preservation behaviour


Benchmark:
[benchmark.py](https://github.com/user-attachments/files/29627909/benchmark.py)
