### PR TITLE
ENH: use native numpy.reshape for numpy>=2.1

### DIFF
--- a/src/array_api_compat/numpy/_aliases.py
+++ b/src/array_api_compat/numpy/_aliases.py
@@ -50,7 +50,10 @@ var = get_xp(np)(_aliases.var)
 cumulative_sum = get_xp(np)(_aliases.cumulative_sum)
 cumulative_prod = get_xp(np)(_aliases.cumulative_prod)
 permute_dims = get_xp(np)(_aliases.permute_dims)
-reshape = get_xp(np)(_aliases.reshape)
+if np.__version__ < '2.1':
+    reshape = get_xp(np)(_aliases.reshape)
+else:
+    reshape = np.reshape
 argsort = get_xp(np)(_aliases.argsort)
 sort = get_xp(np)(_aliases.sort)
 nonzero = get_xp(np)(_aliases.nonzero)

--- a/tests/test_cupy.py
+++ b/tests/test_cupy.py
@@ -1,5 +1,6 @@
 import pytest
 from array_api_compat import device, to_device
+import warnings
 
 xp = pytest.importorskip("array_api_compat.cupy")
 from cupy.cuda import Stream
@@ -43,3 +44,13 @@ def test_to_device_with_dlpack_stream():
         # device context.
         b = to_device(a, dev, stream=s1.ptr)
         assert device(b) == dev
+
+
+def test_reshape_copy_false_returns_a_view_without_deprecation():
+    x = xp.arange(12)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        y = xp.reshape(x, (3, 4), copy=False)
+
+    assert y.shape == (3, 4)
+    assert xp.shares_memory(x, y)

--- a/tests/test_numpy.py
+++ b/tests/test_numpy.py
@@ -139,3 +139,18 @@ def test_matrix_is_not_array_api_obj():
     with warnings.catch_warnings():
         warnings.simplefilter("ignore", PendingDeprecationWarning)
         assert not is_array_api_obj(np.matrix(3))
+
+
+def test_reshape_copy_false_returns_a_view_without_deprecation():
+    x = np.arange(12)
+    with warnings.catch_warnings():
+        warnings.simplefilter("error", DeprecationWarning)
+        y = xp.reshape(x, (3, 4), copy=False)
+
+    assert y.shape == (3, 4)
+    assert np.shares_memory(x, y)
+
+
+def test_reshape_copy_false_rejects_an_input_that_needs_a_copy():
+    with pytest.raises((ValueError, AttributeError)):
+        xp.reshape(np.arange(12).reshape(3, 4).T, (2, 6), copy=False)


### PR DESCRIPTION
`reshape` with `copy=False` assigns to the array shape attribute that numpy 2.5 deprecates.

Bind the numpy namespace `reshape` to the native numpy function from numpy 2.1. That release added the copy argument. Keep the shared workaround for an older numpy.

Leave the cupy and dask paths unchanged. Neither namespace accepts a copy argument, so both still need the shared workaround.
