### PR TITLE
TST: make test_device_to_device resilient on a no_x64 device

### DIFF
--- a/tests/test_array_namespace.py
+++ b/tests/test_array_namespace.py
@@ -24,7 +24,8 @@ def test_array_namespace(request, library, api_version, use_compat):
         pytest.raises(ValueError, lambda: array_namespace(array, use_compat=use_compat))
         return
     if (library == "sparse" and api_version in ("2023.12", "2024.12")) or (
-        library == "jax.numpy" and api_version in ("2021.12", "2022.12", "2023.12")
+        library == "jax.numpy" and
+        api_version in ("2021.12", "2022.12", "2023.12", "2024.12")
     ):
         xfail(request, "Unsupported API version")
 

--- a/tests/test_common.py
+++ b/tests/test_common.py
@@ -203,7 +203,7 @@ def test_device_to_device(library, request):
     devices = xp.__array_namespace_info__().devices()
 
     # Default device
-    x = xp.asarray([1, 2, 3])
+    x = xp.asarray([1, 2, 3], dtype=xp.int32)
     dev = device(x)
 
     for dev in devices:


### PR DESCRIPTION
Observed in gh-454:

> FAILED tests/test_common.py::test_device_to_device[array_api_strict] - ValueError: Device array_api_strict.Device('no_x64') does not support dtype=array_api_strict.int64.

The culprit is that in `-strict`, the "no_x64" device does not support int64, which is a default on the default device. Thus just use int32 explicitly, which is supported everywhere.

EDIT: while at it, skip testing `array_namespace` with api_version=2024.12 and jax.numpy : otherwise jax barfs
that only 2025.12 is supported on python 3.13 and 3.14.

