### PR TITLE
TST: skip test_reshape under numpy < 2 and dask

### DIFF
--- a/dask-xfails.txt
+++ b/dask-xfails.txt
@@ -178,3 +178,6 @@ array_api_tests/test_special_cases.py::test_unary[acosh(real(x_i) is +0 and imag
 array_api_tests/test_dlpack.py::test_dlpack_device
 array_api_tests/test_dlpack.py::test_dunder_dlpack
 array_api_tests/test_dlpack.py::test_from_dlpack
+
+# reshape copy=False code path assigns to the .shape attribute
+array_api_tests/test_manipulation_functions.py::test_reshape

--- a/numpy-1-22-xfails.txt
+++ b/numpy-1-22-xfails.txt
@@ -196,3 +196,6 @@ array_api_tests/test_special_cases.py::test_unary[tanh(real(x_i) is +infinity an
 array_api_tests/test_dlpack.py::test_dlpack_device
 array_api_tests/test_dlpack.py::test_dunder_dlpack
 array_api_tests/test_dlpack.py::test_from_dlpack
+
+# reshape copy=False code path does not handle scalars under NumPy < 2
+array_api_tests/test_manipulation_functions.py::test_reshape

--- a/numpy-1-26-xfails.txt
+++ b/numpy-1-26-xfails.txt
@@ -90,4 +90,5 @@ array_api_tests/test_dlpack.py::test_dlpack_device
 array_api_tests/test_dlpack.py::test_dunder_dlpack
 array_api_tests/test_dlpack.py::test_from_dlpack
 
-
+# reshape copy=False code path does not handle scalars under NumPy < 2
+array_api_tests/test_manipulation_functions.py::test_reshape


### PR DESCRIPTION
The copy=False wrapper does `y.shape = newshape`, and this fails on NumPy < 2 and Dask.