### PR TITLE
fix: define dask reshape copy behavior

### DIFF
--- a/dask-xfails.txt
+++ b/dask-xfails.txt
@@ -178,6 +178,3 @@ array_api_tests/test_special_cases.py::test_unary[acosh(real(x_i) is +0 and imag
 array_api_tests/test_dlpack.py::test_dlpack_device
 array_api_tests/test_dlpack.py::test_dunder_dlpack
 array_api_tests/test_dlpack.py::test_from_dlpack
-
-# reshape copy=False code path assigns to the .shape attribute
-array_api_tests/test_manipulation_functions.py::test_reshape

--- a/src/array_api_compat/dask/array/_aliases.py
+++ b/src/array_api_compat/dask/array/_aliases.py
@@ -129,7 +129,19 @@ ones = get_xp(da)(_aliases.ones)
 ones_like = get_xp(da)(_aliases.ones_like)
 zeros = get_xp(da)(_aliases.zeros)
 zeros_like = get_xp(da)(_aliases.zeros_like)
-reshape = get_xp(da)(_aliases.reshape)
+def reshape(
+    x: Array,
+    /,
+    shape: tuple[int, ...],
+    *,
+    copy: py_bool | None = None,
+    **kwargs: object,
+) -> Array:
+    if copy is True:
+        x = x.copy()
+    return da.reshape(x, shape, **kwargs)
+
+
 matrix_transpose = get_xp(da)(_aliases.matrix_transpose)
 vecdot = get_xp(da)(_aliases.vecdot)
 nonzero = get_xp(da)(_aliases.nonzero)


### PR DESCRIPTION
The shared Dask `reshape` wrapper fails for scalar and 0-size `copy=False` cases.

This change routes Dask `reshape(..., copy=False)` to the native lazy operation and enables the Array API `reshape` test.

This change fixes the Dask issues at [issue 446](https://github.com/data-apis/array-api-tests/issues/446).
